### PR TITLE
Correct return_items syntax for Gloradin in eastwastes

### DIFF
--- a/eastwastes/Gloradin_Coldheart.pl
+++ b/eastwastes/Gloradin_Coldheart.pl
@@ -6,7 +6,7 @@ sub EVENT_ITEM {
     quest::depop(116084);
   }
   else {
-    plugin::return_handin(\%itemcount);
+    plugin::return_items(\%itemcount);
   }
 }
 


### PR DESCRIPTION
Gloradin script in eastwastes was incorrectly calling "return_hadnin" instead of "return_items".