### PR TITLE
[ssratemple] Fix double/respawning quest triggers for Cursed/Rhag.

### DIFF
--- a/ssratemple/encounters/Arch_Lich_Rhag_Zadune.lua
+++ b/ssratemple/encounters/Arch_Lich_Rhag_Zadune.lua
@@ -71,16 +71,16 @@ function reset(e, new_state)
 	eq.depop_all(lich_id);
 
 	set_state(new_state);
-	check_state(e);
+	check_state(e, true);
 end
 
-function check_state(e)
+function check_state(e, check_start)
 	local state = get_state();
 	if state == -1 then
 		return
 	end
 
-	if state == STATE_START then
+	if check_start and state == STATE_START then
 		eq.unique_spawn(zhezum_id, 0, 0, 547, -412, 9.1, 0);
 	end
 
@@ -151,5 +151,5 @@ function event_encounter_load(e)
 
 	eq.register_player_event(Event.say, GMControl);
 
-	check_state(e);
+	check_state(e, false);
 end

--- a/ssratemple/encounters/Cursed_Cycle.lua
+++ b/ssratemple/encounters/Cursed_Cycle.lua
@@ -101,16 +101,16 @@ function reset(e, new_state)
 	eq.depop_all(cursed_id);
 
 	set_state(new_state);
-	check_state(e);
+	check_state(e, true);
 end
 
-function check_state(e)
+function check_state(e, check_start)
 	local state = get_state();
 	if state == -1 then
 		return
 	end
 
-	if state == STATE_START then
+	if check_start and state == STATE_START then
 		eq.unique_spawn(controller_id, 0, 0, 0, 0, 0, 0);
 		local entity_list = eq.get_entity_list();
 		for i,id in ipairs(serpent_triggers) do
@@ -202,5 +202,5 @@ function event_encounter_load(e)
 
 	eq.register_player_event(Event.say, GMControl);
 
-	check_state(e);
+	check_state(e, false);
 end


### PR DESCRIPTION
When I added the GM commands it introduced a behavior that attempts to spawn the trigger npcs for the initial state when the encounter loads instead of just trusting the natural spawns to work.  This created two problems:

1. For NPC's that do not have the necessary database flags to make them unique their natural spawn would sometimes happen AFTER the script had initialized and result in double spawns.
2. If something triggers a quest reload (as is known to happen on release day quite often) it would reinit the encounter and respawn mobs.

This change skips this behavior during normal encounter initialization and just trusts that the server spawn's are working.

I did not fix the Emperor script because there was some talk about disabling the Blood spawn in #contributors earlier which had me worried that I would break the encounter.  The blood spawn is not actually in my PEQ database snapshot but when I wrote the encounter I saw it in the thjdi data so I assumed it was just an issue with the PEQ snapshot.  I'm not sure how else the blood is supposed to spawn unless I've overlooked something.  I don't think the Emp event suffers from this bug though since there's been no reports of it and it looks like the blood has its spawn_limit set to 1.