### PR TITLE
Fixes some PoJ script bugs

### DIFF
--- a/pojustice/201435.lua
+++ b/pojustice/201435.lua
@@ -106,8 +106,8 @@ function event_timer(e)
 		else
 			local client_e = eq.get_entity_list():GetClientByCharID(client_id);
 			if (client_e ~= nil and client_e.valid) then
-				client_e.other:MovePCInstance( 201, eq.get_zone_instance_id(), 456, 825, 9, 360 ); -- Zone: pojustice
-				client_e.other:Message( 3, "A mysterious force translocates you.");
+				client_e:MovePCInstance( 201, eq.get_zone_instance_id(), 456, 825, 9, 360 ); -- Zone: pojustice
+				client_e:Message( 3, "A mysterious force translocates you.");
 			end
 		end
 		HandleCorpses(trial_x, trial_y, trial_z, 200);

--- a/pojustice/201436.lua
+++ b/pojustice/201436.lua
@@ -100,8 +100,8 @@ function event_timer(e)
 		else
 			local client_e = eq.get_entity_list():GetClientByCharID(client_id);
 			if (client_e ~= nil and client_e.valid) then
-					client_e.other:MovePCInstance( 201, instance_id, 456, 825, 9, 360 ); -- Zone: pojustice
-					client_e.other:Message( 3, "A mysterious force translocates you.");
+					client_e:MovePCInstance( 201, instance_id, 456, 825, 9, 360 ); -- Zone: pojustice
+					client_e:Message( 3, "A mysterious force translocates you.");
 			end
 		end
 

--- a/pojustice/201437.lua
+++ b/pojustice/201437.lua
@@ -107,8 +107,8 @@ function event_timer(e)
 		else
 			local client_e = eq.get_entity_list():GetClientByCharID(client_id);
 			if (client_e ~= nil and client_e.valid) then
-				client_e.other:MovePCInstance(201, eq.get_zone_instance_id(), 456, 825, 9, 360 ); -- Zone: pojustice
-				client_e.other:Message(3, "A mysterious force translocates you.");
+				client_e:MovePCInstance(201, eq.get_zone_instance_id(), 456, 825, 9, 360 ); -- Zone: pojustice
+				client_e:Message(3, "A mysterious force translocates you.");
 			end
 		end
 		HandleCorpses(trial_x, trial_y, trial_z, 200);

--- a/pojustice/201438.lua
+++ b/pojustice/201438.lua
@@ -102,8 +102,8 @@ function event_timer(e)
 		else
             local client_e = eq.get_entity_list():GetClientByCharID(client_id);
             if (client_e ~= nil and client_e.valid) then
-                client_e.other:MovePCInstance( 201, eq.get_zone_instance_id(), 456, 825, 9, 360 ); -- Zone: pojustice
-                client_e.other:Message(3, "A mysterious force translocates you.");
+                client_e:MovePCInstance( 201, eq.get_zone_instance_id(), 456, 825, 9, 360 ); -- Zone: pojustice
+                client_e:Message(3, "A mysterious force translocates you.");
             end
 		end
 		HandleCorpses(772, -1148, 76, 175);


### PR DESCRIPTION
These are spamming errors because of invalid field indexes -- `client_e` is already a reference to a LuaClient