### PR TITLE
Seer and Gram fix

### DIFF
--- a/poknowledge/Gram_Dunnar.lua
+++ b/poknowledge/Gram_Dunnar.lua
@@ -82,7 +82,6 @@ function event_say(e)
 			end
 		else
 			e.self:Say("I've already heard all of those stories!")
-			e.other:DeleteAccountBucket("pop.flags.story")
 		end	
 	elseif e.message:findi("craft") then
 		e.self:Emote("Gram Dunnar stops carving and holds up the object between his short fingers. It is a figurine of a swordsman with many intricate details. 'No one really wants to buy them, these days. If there's no magic in it...' he shrugs. 'Still, something to take up some time.' He rummages through some finished pieces on the floor around him, picks up one, and tosses it to you. 'Here,' he says. 'Maybe it'll bring you some luck.")

--- a/poknowledge/Seer_Mal_Nae-Shi.lua
+++ b/poknowledge/Seer_Mal_Nae-Shi.lua
@@ -41,12 +41,13 @@ function event_say(e)
 		["pop.flags.trell"] = 1,
 		["pop.flags.valor"] = 1,
 		["pop.flags.xanamech"] = 1
+		["pop.flags.story"] = 7
 	}
 
 	if e.message:findi("Hail") then
 		for flag, required_value in pairs(flags) do
 			local flag_value = tonumber(e.other:GetAccountBucket(flag)) or 0
-			local status_message = (flag == required_value) and "Complete" or "Incomplete"
+			local status_message = (flag_value == required_value) and "Complete" or "Incomplete"
 			local status_link = eq.silent_say_link(status_message)
 
 			local type = (flag:findi("pop.flags")) and "Flag" or "Alternate Access"


### PR DESCRIPTION
Seer outputs wrong result due to seemingly wrong comparison. Fixed comparison.

Gram deletes the entire POP bucket when DeleteAccountBucket is called. In report, on mismatch say (craft) but this should just prevent it regardless.

Also added a Seer check for the bucket thats no longer deleted.