### PR TITLE
Tribunal Syntax Alignment

### DIFF
--- a/pojustice/201435.lua
+++ b/pojustice/201435.lua
@@ -31,7 +31,7 @@ function event_say(e)
 			local begin_the_trial_of_stoning_link = eq.silent_say_link("begin the trial of stoning");
 			e.self:Say(
 				string.format(
-					"Very well. When you are ready, you may [%s]. You must protect the victims from their tormentors. Be wary of the scourge of honor - you cannot fight it directly. You must find and destroy its life force to defeat it. We shall judge the mark of your success.",
+					"Very well. When you are ready, you may [%s]. The archers will not cease their punishment until nothing else stands.  Do not let the prisoners take more than they can bear.  We shall judge the mark of your success.",
 					begin_the_trial_of_stoning_link
 				)
 			)

--- a/pojustice/201436.lua
+++ b/pojustice/201436.lua
@@ -30,7 +30,7 @@ function event_say(e)
 			local begin_the_trial_of_torture_link = eq.silent_say_link("begin the trial of torture");
 			e.self:Say(
 				string.format(
-					"Very well. When you are ready, you may [%s]. You must protect the victims from their tormentors. Be wary of the scourge of honor - you cannot fight it directly. You must find and destroy its life force to defeat it. We shall judge the mark of your success.",
+					"Very well. When you are ready, you may [%s]. Only when a wraith of agony dies will the prisoners feel any relief.  Take care to find and kill it quickly, lest their torment overcome them. We shall judge the mark of your success.",
 					begin_the_trial_of_torture_link
 				)
 			)

--- a/pojustice/201437.lua
+++ b/pojustice/201437.lua
@@ -32,7 +32,7 @@ function event_say(e)
 			local begin_the_trial_of_hanging_link = eq.silent_say_link("begin the trial of hanging");
 			e.self:Say(
 				string.format(
-					"Very well. When you are ready, you may [%s]. You must protect the victims from their tormentors. Be wary of the scourge of honor - you cannot fight it directly. You must find and destroy its life force to defeat it. We shall judge the mark of your success.",
+					"Very well. When you are ready, you may [%s]. Act quickly to destroy the spirits of suffocation before their victims perish.  We shall judge the mark of your success.",
 					begin_the_trial_of_hanging_link
 				)
 			)


### PR DESCRIPTION
Some of the quest syntax that gives direction to the goal of each trial was not correct.  This PR corrects them.  Functionally no changes, just cosmetic saytext correction.