### PR TITLE
Updating p1 encounters to handle zone state saving

### DIFF
--- a/potimeb/phase_one_air.lua
+++ b/potimeb/phase_one_air.lua
@@ -21,12 +21,19 @@ function event_spawn(e)
 end
 
 function event_enter(e)
-	-- tell zone_status phase 1 was started
-	eq.signal(223097,1,5*1000);
-	-- wait 45 seconds before spawning the mobs.
-	eq.clear_proximity();
-	eq.set_timer("Phase1Air",45000);
-	eq.set_timer("player_count",5 * 1000);	--check to ensure only 18 players in trial area
+	if tonumber(eq.get_zone():GetBucket("Neimon of Air")) or 0 > 0 then
+		eq.zone_emote(14,"You have already completed the Trial of Air!");
+	else
+		for index, mob in ipairs(event_mobs) do
+			eq.depop_all(mob);
+		end
+		-- tell zone_status phase 1 was started
+		eq.signal(223097,1,5*1000);
+		-- wait 45 seconds before spawning the mobs.
+		eq.clear_proximity();
+		eq.set_timer("Phase1Air",10000);
+		eq.set_timer("player_count",5 * 1000);	--check to ensure only 18 players in trial area
+	end
 end
 
 function event_timer(e)

--- a/potimeb/phase_one_earth.lua
+++ b/potimeb/phase_one_earth.lua
@@ -5,6 +5,8 @@
 local event_counter = 0;
 local terlok = false;
 
+local event_mobs = {223106,223119,223147};
+
 --specify trial boundaries for player check routine
 local min_x = -75;
 local max_x = 90;
@@ -21,12 +23,19 @@ function event_spawn(e)
 end
 
 function event_enter(e)
-	-- tell zone_status phase 1 was started
-	eq.signal(223097,1,5*1000);
-	-- wait 45 seconds before spawning the mobs.
-	eq.clear_proximity();
-	eq.set_timer("Phase1Earth",45000);
-	eq.set_timer("player_count",5 * 1000);	--check to ensure only 18 players in trial area
+	if tonumber(eq.get_zone():GetBucket("Terlok of Earth")) or 0 > 0 then
+		eq.zone_emote(14,"You have already completed the Trial of Earth!");
+	else
+		for index, mob in ipairs(event_mobs) do
+			eq.depop_all(mob);
+		end
+		-- tell zone_status phase 1 was started
+		eq.signal(223097,1,5*1000);
+		-- wait 45 seconds before spawning the mobs.
+		eq.clear_proximity();
+		eq.set_timer("Phase1Earth",10000);
+		eq.set_timer("player_count",5 * 1000);	--check to ensure only 18 players in trial area
+	end
 end
 
 function event_timer(e)

--- a/potimeb/phase_one_fire.lua
+++ b/potimeb/phase_one_fire.lua
@@ -21,12 +21,20 @@ function event_spawn(e)
 end
 
 function event_enter(e)
-	-- tell zone_status phase 1 was started
-	eq.signal(223097,1,5*1000);
-	-- wait 45 seconds before spawning the mobs.
-	eq.clear_proximity();
-	eq.set_timer("Phase1Fire",45000);
-	eq.set_timer("player_count",5 * 1000);	--check to ensure only 18 players in trial area
+	if tonumber(eq.get_zone():GetBucket("Kazrok of Fire")) or 0 > 0 then
+		eq.zone_emote(14,"You have already completed the Trial of Fire!");
+	else
+		-- Depop everything to prevent double spawns
+		for index, mob in ipairs(event_mobs) do
+			eq.depop_all(mob);
+		end
+		-- tell zone_status phase 1 was started
+		eq.signal(223097,1,5*1000);
+		-- wait 45 seconds before spawning the mobs.
+		eq.clear_proximity();
+		eq.set_timer("Phase1Fire",10000);
+		eq.set_timer("player_count",5 * 1000);	--check to ensure only 18 players in trial area
+	end
 end
 
 function event_timer(e)

--- a/potimeb/phase_one_undead.lua
+++ b/potimeb/phase_one_undead.lua
@@ -21,12 +21,20 @@ function event_spawn(e)
 end
 
 function event_enter(e)
-	-- tell zone_status phase 1 was started
-	eq.signal(223097,1,5*1000);
-	-- wait 45 seconds before spawning the mobs.
-	eq.clear_proximity();
-	eq.set_timer("Phase1Undead",45000);
-	eq.set_timer("player_count",5 * 1000);	--check to ensure only 18 players in trial area
+	if tonumber(eq.get_zone():GetBucket("Rythor of the Undead")) or 0 > 0 then
+		eq.zone_emote(14,"You have already completed the Trial of Undead!");
+	else
+		-- depop all mobs to prevent duplicates
+		for index, mob in ipairs(event_mobs) do
+			eq.depop_all(mob);
+		end
+		-- tell zone_status phase 1 was started
+		eq.signal(223097,1,5*1000);
+		-- wait 45 seconds before spawning the mobs.
+		eq.clear_proximity();
+		eq.set_timer("Phase1Undead",10000);
+		eq.set_timer("player_count",5 * 1000);	--check to ensure only 18 players in trial area
+	end
 end
 
 function event_timer(e)

--- a/potimeb/phase_one_water.lua
+++ b/potimeb/phase_one_water.lua
@@ -21,12 +21,20 @@ function event_spawn(e)
 end
 
 function event_enter(e)
-	-- tell zone_status phase 1 was started
-	eq.signal(223097,1,5*1000);
-	-- wait 45 seconds before spawning the mobs.
-	eq.clear_proximity();
-	eq.set_timer("Phase1Water",45000);
-	eq.set_timer("player_count",5 * 1000);	--check to ensure only 18 players in trial area
+	if tonumber(eq.get_zone():GetBucket("Anar of Water")) or 0 > 0 then
+		eq.zone_emote(14,"You have already completed the Trial of Water!");
+	else
+		-- depop all mobs to prevent duplicates
+		for index, mob in ipairs(event_mobs) do
+			eq.depop_all(mob);
+		end
+		-- tell zone_status phase 1 was started
+		eq.signal(223097,1,5*1000);
+		-- wait 45 seconds before spawning the mobs.
+		eq.clear_proximity();
+		eq.set_timer("Phase1Water",10000);
+		eq.set_timer("player_count",5 * 1000);	--check to ensure only 18 players in trial area
+	end
 end
 
 function event_timer(e)

--- a/potimeb/player.lua
+++ b/potimeb/player.lua
@@ -404,11 +404,20 @@ function event_say(e)
 			e.self:Message(MT.Guild,string.format("- [%s] -",eq.say_link("tb_p6",false,"Phase 6")));
 		elseif e.message:find("tb_p1") then
 			eq.set_data(expedition_identifier,"0");
+			eq.get_zone():DeleteBucket("Kazrok of Fire");
+			eq.get_zone():DeleteBucket("Terlok of Earth");
+			eq.get_zone():DeleteBucket("Anar of Water");
+			eq.get_zone():DeleteBucket("Neimon of Air");
+			eq.get_zone():DeleteBucket("Rythor of the Undead");
 			ResetLockouts(99);
 			ZoneReset(e);
 			e.self:Message(MT.Lime,"[Phase 1 Loading]");
 		elseif e.message:find("tb_p2") then
 			eq.set_data(expedition_identifier,"1");
+			eq.get_zone():DeletEBucket("War Shapen Emissary");
+			eq.get_zone():DeleteBucket("Gutripping War Beast");
+			eq.get_zone():DeleteBucket("Earthen Overseer");
+			eq.get_zone():DeleteBucket("Windshapen Warlord of Air");
 			ResetLockouts(99);
 			SetLockouts(1);
 			ZoneReset(e);

--- a/potimeb/zone_status.lua
+++ b/potimeb/zone_status.lua
@@ -203,9 +203,15 @@ function event_signal(e)
 	-- signal 2 comes from the mobs in the final wave of each phase 1 event
 	elseif e.signal == 2 then
 		-- check that all 5 phase 1 events are down.
-		event_counter = event_counter +1
+		local p1Complete = 0;
+		local p1FireComplete = tonumber(eq.get_zone():GetBucket("Kazrok of Fire")) or 0
+		local p1UndeadComplete = tonumber(eq.get_zone():GetBucket("Rythor of the Undead")) or 0
+		local p1WaterComplete = tonumber(eq.get_zone():GetBucket("Anar of Water")) or 0
+		local p1EarthComplete = tonumber(eq.get_zone():GetBucket("Terlok of Earth")) or 0
+		local p1AirComplete = tonumber(eq.get_zone():GetBucket("Neimon of Air")) or 0
+		p1Complete = p1FireComplete + p1UndeadComplete + p1WaterComplete + p1EarthComplete + p1AirComplete
 
-		if event_counter >= 5 then
+		if p1Complete >= 5 then
 			local expedition_identifier = string.format("potime-%d-phase", expedition:GetID())
 			local phase_bucket = tonumber(eq.get_data(expedition_identifier)) or 0
 			if phase_bucket == 0 then -- Moving to Phase 2


### PR DESCRIPTION
- Reduce p1 trial spawn timer to 10 seconds (down from 45)
- Update the zone_status logic controller to specifically check against buckets for each p1 trial boss instead of a generic counter that wasn't being saved as part of state
- Update player.lua to properly reset buckets for p1 and p2 when using gm commands
- Added an emote when a player goes into a p1 trial they've already completed
- Added logic to depop all mobs related to a p1 trial to prevent duplicate mobs from spawning.  A player could enter the trigger area, camp out, then log back in after the zone was spun down to get a second set of NPCs and sometimes bosses.