### PR TITLE
Update #Vallon_Zek_.lua

### DIFF
--- a/potactics/#Tallon_Zek.lua
+++ b/potactics/#Tallon_Zek.lua
@@ -45,9 +45,13 @@ end
 
 function event_waypoint_arrive(e)
 	if e.wp == 9 then
-		eq.spawn2(214086, 0, 0, 301, -57, 169, 0) --Hendin_Shadow_Master (214086)
-		eq.spawn2(214086, 0, 0, 271, -57, 169, 0) --Hendin_Shadow_Master (214086)
-		eq.spawn2(214086, 0, 0, 361, -57, 169, 0) --Hendin_Shadow_Master (214086)
-		eq.spawn2(214086, 0, 0, 391, -57, 169, 0) --Hendin_Shadow_Master (214086)
+		local adds = tonumber(eq.get_zone():GetVariable("tzhendin")) or 0
+		if adds == 0 then
+			eq.spawn2(214086, 0, 0, 301, -57, 169, 0) --Hendin_Shadow_Master (214086)
+			eq.spawn2(214086, 0, 0, 271, -57, 169, 0) --Hendin_Shadow_Master (214086)
+			eq.spawn2(214086, 0, 0, 361, -57, 169, 0) --Hendin_Shadow_Master (214086)
+			eq.spawn2(214086, 0, 0, 391, -57, 169, 0) --Hendin_Shadow_Master (214086)
+		end
+		eq.get_zone():SetVariable("tzhendin", "1")
 	end
 end

--- a/potactics/#Vallon_Zek_.lua
+++ b/potactics/#Vallon_Zek_.lua
@@ -34,6 +34,7 @@ function event_combat(e)
 		eq.set_timer("OOBcheck", 6 * 1000)
 	else
 --		eq.resume_timer("depop")
+		eq.depop_all(214129) -- depop VZ splits when combat ends with #Vallon_zek_
 		eq.stop_timer("OOBcheck")
 	end
 end

--- a/potactics/#Vallon_Zek_.lua
+++ b/potactics/#Vallon_Zek_.lua
@@ -14,10 +14,14 @@ end
 
 function event_waypoint_arrive(e)
 	if e.wp == 9 then
-		eq.spawn2(214084, 0, 0, 359, 73, 169, 255) --Gindan_Flayer 214084
-		eq.spawn2(214084, 0, 0, 383, 73, 169, 255) --Gindan_Flayer 214084
-		eq.spawn2(214084, 0, 0, 308, 73, 169, 255) --Gindan_Flayer 214084
-		eq.spawn2(214084, 0, 0, 283, 73, 169, 255) --Gindan_Flayer 214084
+		local adds = tonumber(eq.get_zone():GetVariable("vzflayers")) or 0
+		if adds == 0 then
+			eq.spawn2(214084, 0, 0, 359, 73, 169, 255) --Gindan_Flayer 214084
+			eq.spawn2(214084, 0, 0, 383, 73, 169, 255) --Gindan_Flayer 214084
+			eq.spawn2(214084, 0, 0, 308, 73, 169, 255) --Gindan_Flayer 214084
+			eq.spawn2(214084, 0, 0, 283, 73, 169, 255) --Gindan_Flayer 214084
+		end
+		eq.get_zone():SetVariable("vzflayers", "1")
 	end
 end
 


### PR DESCRIPTION
Depop RZTWL VZ split VZ's when original VZ drops combat to avoid repeated wipes spawning multiple sets of adds. Also RZTWL VZ/TZ will only spawn waypoint 9 adds once. I could not replicate the reported issue on test, but it cannot happen anymore.