### PR TITLE
Resolving a few issues around porting NPCs in potorment

### DIFF
--- a/potorment/#Tylis_Newleaf.lua
+++ b/potorment/#Tylis_Newleaf.lua
@@ -1,12 +1,18 @@
 function event_spawn(e)
-	eq.set_timer("Depop", 1200 * 1000) -- 20 Minutes
+	if not tostring(eq.get_zone_instance_version()) == eq.get_rule("Custom:StaticInstanceVersion") then
+		eq.set_timer("Depop", 1200 * 1000) -- 20 minutes in OW only
+	end
+	e.self:SetSpecialAbility(19, 1); -- Immune to melee
+	e.self:SetSpecialAbility(20, 1); -- Immune to magic
+	e.self:SetSpecialAbility(24, 1); -- Will not aggro
+	e.self:SetSpecialAbility(35, 1); -- No harm from players
 end
 
 function event_timer(e)
-	if e.timer == "Depop" then
-		eq.stop_timer("Depop")
-		eq.depop()
-	end
+        if e.timer == "Depop" then
+                eq.stop_timer("Depop")
+                eq.depop()
+        end
 end
 
 function event_say(e)
@@ -23,7 +29,10 @@ function event_say(e)
 			e.other:SetAccountBucket("pop.flags.newleaf", "1")
 			e.other:Message(MT.LightBlue, "You receive a character flag!")
 		else
-			e.self:Say("It looks like we've already spoken.")
+			local ready_link = eq.silent_say_link("ready")
+			e.self:Say(
+				string.format(
+					"It looks like we've already spoken.  Are you %s to continue?",ready_link))
 		end
 	elseif e.message:findi("ready") then
 		e.other:Message(MT.LightBlue, "Your tormented visions have ended.")

--- a/potorment/207031.pl
+++ b/potorment/207031.pl
@@ -1,16 +1,7 @@
 ##An_Unimaginable_Horror (207031)
 
-sub EVENT_SPAWN {
-	quest::settimer(2,1800); #fail timer; 30 minutes
-}
-
-sub EVENT_TIMER {
-	if($timer == 2) {
-		quest::depop();
-	}
-}
-
 sub EVENT_DEATH_COMPLETE {
+	quest::signalwith(207028,1);
 	quest::spawn2(207082,0,0,1,-1021,-27,0); #Real #Baraguj_Szuul
 	my @clientlist = $entity_list->GetClientList();
 	foreach $ent (@clientlist) {

--- a/potorment/Baraguj_Szuul.pl
+++ b/potorment/Baraguj_Szuul.pl
@@ -1,14 +1,10 @@
-sub EVENT_COMBAT {
-	my @clientlist = $entity_list->GetClientList();
-	foreach $ent (@clientlist) {
-		#distance restriction so the members need to be reasonably close.
-		if ($ent->CalculateDistance($npc->GetX(),$npc->GetY(),$npc->GetZ()) <= 100) {
-		$ent->MovePCInstance(207, $instanceid, -1094,910,-746,0); # Zone: potorment
-		}
+sub EVENT_ENTER {
+	quest::ze(14,"Baraguj Szuul lunges forward to devour his prey");
+	if (!($zone->VariableExists("stomach"))){
+		quest::signal(207071);
+		$zone->SetVariable("stomach","1");
 	}
-	#signal mouth_trigger that spawns all the mobs in stomach
-	quest::signal(207071);
-	quest::settimer(1,5);
+	$client->MovePCInstance(207, $instanceid, -1094,910,-748,0);
 }
 
 sub EVENT_TIMER {
@@ -16,5 +12,17 @@ sub EVENT_TIMER {
 }
 
 sub EVENT_SPAWN {
-	$npc->SetSpecialAbility(1,0); # disable summon special attack on the "fake" Baraguj to prevent instant summon back to him in case player deals massive damage on initial engage
+	my $mb = $entity_list->GetMobByNpcTypeID(207028);
+	$mb->SetSpecialAbility(19,1); # immune to melee
+	$mb->SetSpecialAbility(20,1); # immune to magic
+	$mb->SetSpecialAbility(24,1); # will not aggro
+	quest::set_proximity_range(40,40,10); # set proximity range
+}
+
+sub EVENT_SIGNAL {
+	if ($signal == 1) {
+		# Mouth has been cleared, depop
+		$zone->DeleteVariable("stomach");
+		quest::settimer(1,5);
+	}
 }

--- a/potorment/The_Keeper_of_Sorrows.pl
+++ b/potorment/The_Keeper_of_Sorrows.pl
@@ -15,6 +15,8 @@ sub EVENT_TIMER {
 }
 
 sub EVENT_DEATH_COMPLETE {
-    quest::signal(207014,0); # NPC: Tylis_Newleaf
+    if ($zone->GetInstanceVersion() ne quest::get_rule("Custom:StaticInstanceVersion")+0){
+	quest::signal(207014,0); # NPC: Tylis_Newleaf, depop only in open world
+    }
     quest::spawn2(207066,0,0,$x,$y,$z,$h); # NPC: #Tylis_Newleaf
 }

--- a/potorment/mouth_trigger.pl
+++ b/potorment/mouth_trigger.pl
@@ -1,24 +1,29 @@
 sub EVENT_SIGNAL {
+	# Depop all of the mobs before we spawn them to prevent duplicate spawns
+	quest::depopall(207033);
+	quest::depopall(207032);
+	quest::depopall(207031);
+	
 
-quest::spawn2(207033,0,0,-635,890,-1240,260); # needs_heading_validation
-quest::spawn2(207033,0,0,-633,926,-1247,380); # NPC: A_skinless_creature
-quest::spawn2(207033,0,0,-658,961,-1241,0); # NPC: A_skinless_creature
-quest::spawn2(207033,0,0,-736,971,-1240,284); # NPC: A_skinless_creature
-quest::spawn2(207033,0,0,-738,890,-1240,414); # NPC: A_skinless_creature
-quest::spawn2(207033,0,0,-738,890,-1240,414); # NPC: A_skinless_creature
-quest::spawn2(207033,0,0,-871,931,-1242,0); # NPC: A_skinless_creature
-quest::spawn2(207033,0,0,-949,952,-1239,0); # NPC: A_skinless_creature
-quest::spawn2(207032,0,0,-959,921,-1240,0); # NPC: A_flayed_horror
-quest::spawn2(207032,0,0,-1084,924,-1240,68); # NPC: A_flayed_horror
-quest::spawn2(207032,0,0,-1083,1003,-1240,200); # NPC: A_flayed_horror
-quest::spawn2(207032,0,0,-957,1001,-1240,0); # NPC: A_flayed_horror
-quest::spawn2(207032,0,0,-930,989,-1433,144); # NPC: A_flayed_horror
-quest::spawn2(207032,0,0,-901,993,-1439,178); # NPC: A_flayed_horror
-quest::spawn2(207032,0,0,-846,920,-1448,480); # NPC: A_flayed_horror
-quest::spawn2(207032,0,0,-756,923,-1433,492); # NPC: A_flayed_horror
-quest::spawn2(207032,0,0,-753,918,-1640,0); # NPC: A_flayed_horror
-quest::spawn2(207032,0,0,-754,988,-1640,0); # NPC: A_flayed_horror
-quest::spawn2(207032,0,0,-859,990,-1641,176); # NPC: A_flayed_horror
-quest::spawn2(207031,0,0,-789,997,-1633,316); # NPC: An_Unimaginable_Horror
+	quest::spawn2(207033,0,0,-635,890,-1240,260); # needs_heading_validation
+	quest::spawn2(207033,0,0,-633,926,-1247,380); # NPC: A_skinless_creature
+	quest::spawn2(207033,0,0,-658,961,-1241,0); # NPC: A_skinless_creature
+	quest::spawn2(207033,0,0,-736,971,-1240,284); # NPC: A_skinless_creature
+	quest::spawn2(207033,0,0,-738,890,-1240,414); # NPC: A_skinless_creature
+	quest::spawn2(207033,0,0,-738,890,-1240,414); # NPC: A_skinless_creature
+	quest::spawn2(207033,0,0,-871,931,-1242,0); # NPC: A_skinless_creature
+	quest::spawn2(207033,0,0,-949,952,-1239,0); # NPC: A_skinless_creature
+	quest::spawn2(207032,0,0,-959,921,-1240,0); # NPC: A_flayed_horror
+	quest::spawn2(207032,0,0,-1084,924,-1240,68); # NPC: A_flayed_horror
+	quest::spawn2(207032,0,0,-1083,1003,-1240,200); # NPC: A_flayed_horror
+	quest::spawn2(207032,0,0,-957,1001,-1240,0); # NPC: A_flayed_horror
+	quest::spawn2(207032,0,0,-930,989,-1433,144); # NPC: A_flayed_horror
+	quest::spawn2(207032,0,0,-901,993,-1439,178); # NPC: A_flayed_horror
+	quest::spawn2(207032,0,0,-846,920,-1448,480); # NPC: A_flayed_horror
+	quest::spawn2(207032,0,0,-756,923,-1433,492); # NPC: A_flayed_horror
+	quest::spawn2(207032,0,0,-753,918,-1640,0); # NPC: A_flayed_horror
+	quest::spawn2(207032,0,0,-754,988,-1640,0); # NPC: A_flayed_horror
+	quest::spawn2(207032,0,0,-859,990,-1641,176); # NPC: A_flayed_horror
+	quest::spawn2(207031,0,0,-789,997,-1633,316); # NPC: An_Unimaginable_Horror
 }
 


### PR DESCRIPTION
- Updated Baraguj to automatically port the player to the stomach when they enter a small proximity (enter his room).  He will only trigger the spawn of NPCs in the stomach the first time his proximity is triggered.
- A few updates to support zone state (open world may still be a bit iffy)
- Updated stomach controller to depop the relevant mobs before popping them to prevent double spawns (mostly applicable in open world)
- Updated Tylis to not depop in non-respawning DZ
- Updated Tylis text to be more clear about say phrase to continue