### PR TITLE
[Performance] Migrate Buckets to Utilize Cache

### DIFF
--- a/bazaar/#Sage_of_Anachronism.pl
+++ b/bazaar/#Sage_of_Anachronism.pl
@@ -28,10 +28,10 @@ sub EVENT_SAY {
             plugin::NPCTell("You have set upon a path of rememberence. Are you [ready] to proceed?");
         } else {
             plugin::NPCTell("Hail, Adventurer. I am here in order to grant you access certain [Fabled Memories], through which you can experience past events in a new light.");
-            if (quest::get_data($client->AccountID() . "-season-1-participation") && !plugin::check_hasitem($client, 200000) && $client->IsSeasonal()) {
+            if ($client->GetAccountBucket("season-1-participation") && !plugin::check_hasitem($client, 200000) && $client->IsSeasonal()) {
                 plugin::NPCTell("It also appears as if you have lost your [".quest::saylink("First Orb of Retribution", 1)."]. Would you like me to replace it?");
             }
-            quest::debug(quest::get_data($client->AccountID() . "-season-1-participation") .":". !plugin::check_hasitem($client, 200000) .":". $client->IsSeasonal());
+            quest::debug($client->GetAccountBucket("season-1-participation") .":". !plugin::check_hasitem($client, 200000) .":". $client->IsSeasonal());
         }        
         # Never continue after handling a basic hail.
         return;
@@ -42,7 +42,7 @@ sub EVENT_SAY {
         return;
     }
 
-    if ($text=~/First Orb of Retribution/i && quest::get_data($client->AccountID() . "-season-1-participation") && !plugin::check_hasitem($client, 200000)) {
+    if ($text=~/First Orb of Retribution/i && $client->GetAccountBucket("season-1-participation") && !plugin::check_hasitem($client, 200000)) {
         plugin::NPCTell("But of course. Here, try to be more careful with this one.");
         $client->SummonFixedItem(200000);
     }

--- a/bazaar/Other_Elvish_Security_Officer.pl
+++ b/bazaar/Other_Elvish_Security_Officer.pl
@@ -19,8 +19,8 @@ sub EVENT_ITEM {
             quest::summonfixeditem($reward);
         }
 
-        my $account_key 	= $client->AccountID() . "-ess-items-returned";
-        quest::set_data($account_key, (quest::get_data($account_key) || 0) + 1);
+        my $account_key 	= "ess-items-returned";
+        $client->SetAccountBucket($account_key, ($client->GetAccountBucket($account_key) || 0) + 1);
     }
 
     plugin::return_items(\%itemcount);

--- a/bazaar/Tearel.pl
+++ b/bazaar/Tearel.pl
@@ -1,5 +1,5 @@
 sub EVENT_SAY {
-  my $group_flg       = quest::get_data($client->AccountID() ."-group-ports-enabled") || "";  
+  my $group_flg       = $client->GetAccountBucket("group-ports-enabled") || "";  
   my $eom_link        = quest::varlink(46779);
 
   my $bind_loc        = $client->GetBucket("baz_and_back_bind") || 'bazaar';
@@ -68,7 +68,7 @@ sub EVENT_SAY {
       plugin::NPCTell("You already have performed this ritual, and have these abilities available to you.");
     } else {
       if (plugin::SpendEOM($client, 5)) {
-        quest::set_data($client->AccountID() ."-group-ports-enabled", 1);
+        $client->SetAccountBucket("group-ports-enabled", 1);
         plugin::NPCTell("$name, forevermore you and yours can transport your entire group to anywhere you have [attuned].");
       } else {
         plugin::NPCTell("I'm sorry, $name, you do not have enough [".$eom_link."] available to you right now. When you have more...");

--- a/ecommons/Other_Elvish_Security_Officer.pl
+++ b/ecommons/Other_Elvish_Security_Officer.pl
@@ -19,8 +19,8 @@ sub EVENT_ITEM {
             quest::summonfixeditem($reward);
         }
 
-        my $account_key 	= $client->AccountID() . "-ess-items-returned";
-        quest::set_data($account_key, (quest::get_data($account_key) || 0) + 1);
+        my $account_key 	= "ess-items-returned";
+        $client->SetAccountBucket($account_key, ($client->GetAccountBucket($account_key) || 0) + 1);
     }
 
     plugin::return_items(\%itemcount);

--- a/ecommons/Son_of_Tearel.pl
+++ b/ecommons/Son_of_Tearel.pl
@@ -1,5 +1,5 @@
 sub EVENT_SAY {
-  my $group_flg       = quest::get_data($client->AccountID() ."-group-ports-enabled") || "";  
+  my $group_flg       = $client->GetAccountBucket("group-ports-enabled") || "";  
   my $eom_link        = quest::varlink(46779);
 
   my $bind_loc        = $client->GetBucket("baz_and_back_bind") || 'bazaar';
@@ -68,7 +68,7 @@ sub EVENT_SAY {
       plugin::NPCTell("You already have performed this ritual, and have these abilities available to you.");
     } else {
       if (plugin::SpendEOM($client, 5)) {
-        quest::set_data($client->AccountID() ."-group-ports-enabled", 1);
+        $client->GetAccountBucket("group-ports-enabled", 1);
         plugin::NPCTell("$name, forevermore you and yours can transport your entire group to anywhere you have [attuned].");
       } else {
         plugin::NPCTell("I'm sorry, $name, you do not have enough [".$eom_link."] available to you right now. When you have more...");

--- a/ecommons/player.pl
+++ b/ecommons/player.pl
@@ -40,7 +40,7 @@ sub EVENT_CLICKDOOR {
 
 sub EVENT_POPUPRESPONSE {
     if ($popupid == 1460 || $popupid == 1461) {
-        my $group_flg           = quest::get_data($client->AccountID() ."-group-ports-enabled") || "";
+        my $group_flg           = $client->GetAccountBucket("group-ports-enabled") || "";
         my $attuned_shortname   = $client->GetEntityVariable("magic_map_attune");
         my $waypoint_data       = plugin::GetWaypoint($attuned_shortname, $client);
         my $group               = $client->GetGroup();

--- a/global/Other_Elvish_Security_Officer.pl
+++ b/global/Other_Elvish_Security_Officer.pl
@@ -19,8 +19,8 @@ sub EVENT_ITEM {
             quest::summonfixeditem($reward);
         }
 
-        my $account_key 	= $client->AccountID() . "-ess-items-returned";
-        quest::set_data($account_key, (quest::get_data($account_key) || 0) + 1);
+        my $account_key 	= "ess-items-returned";
+        $client->SetAccountBucket($account_key, ($client->GetAccountBucket($account_key) || 0) + 1);
     }
 
     plugin::return_items(\%itemcount);
@@ -63,8 +63,8 @@ sub EVENT_ITEM {
             quest::summonfixeditem($reward);
         }
 
-        my $account_key 	= $client->AccountID() . "-ess-items-returned";
-        quest::set_data($account_key, (quest::get_data($account_key) || 0) + 1);
+        my $account_key 	= "ess-items-returned";
+        $client->SetAccountBucket($account_key, ($client->GetAccountBucket($account_key) || 0) + 1);
     }
 
     plugin::return_items(\%itemcount);

--- a/global/global_player.pl
+++ b/global/global_player.pl
@@ -193,10 +193,10 @@ sub EVENT_WARP {
     my $current_y = $client->GetY();
     my $current_z = $client->GetZ();
     my $distance = sqrt(($current_x - $from_x) ** 2 + ($current_y - $from_y) ** 2 + ($current_z - $from_z) ** 2);
-    my $account_key = $client->AccountID() . "-WarpCount";
-    my $soulmark = quest::get_data($client->AccountID() . "-CheaterFlag");
+    my $account_key = "WarpCount";
+    my $soulmark = $client->GetAccountBucket("CheaterFlag");
 
-    my @warp_events = plugin::DeserializeList(quest::get_data($account_key));
+    my @warp_events = plugin::DeserializeList($client->GetAccountBucket($account_key));
 
     # Enqueue the current warp event with timestamp
     push @warp_events, time();
@@ -210,7 +210,7 @@ sub EVENT_WARP {
 
     my $enforcement = 0;
 
-    quest::set_data($account_key, plugin::SerializeList(@warp_events));
+    $client->SetAccountBucket($account_key, plugin::SerializeList(@warp_events));
 
     if ($distance > 100 || $soulmark) {
         my $admin_message = "Large Warp Detected. Character: $name Zone: $zonesn From: $from_x, $from_y, $from_z To: $current_x, $current_y, $current_z Distance: $distance";

--- a/global/items/Ret_Season1.pl
+++ b/global/items/Ret_Season1.pl
@@ -1,24 +1,24 @@
 sub EVENT_SCALE_CALC {
-    my $participation_value = quest::get_data($client->AccountID() . "-season-1-participation") || 0;
+    my $participation_value = $client->GetAccountBucket("season-1-participation") || 0;
     my $participation_max   = 100;
 
-    if (quest::get_data($client->AccountID() . "-season-1-participation-RoK")) {
+    if ($client->GetAccountBucket("season-1-participation-RoK")) {
         $participation_value += 10;
     }
 
-    if (quest::get_data($client->AccountID() . "-season-1-participation-SoV")) {
+    if ($client->GetAccountBucket("season-1-participation-SoV")) {
         $participation_value += 10;
     }
 
-    if (quest::get_data($client->AccountID() . "-season-1-participation-SoL")) {
+    if ($client->GetAccountBucket("season-1-participation-SoL")) {
         $participation_value += 10;
     }
 
-    if (quest::get_data($client->AccountID() . "-season-1-participation-PoP")) {
+    if ($client->GetAccountBucket("season-1-participation-PoP")) {
         $participation_value += 10;
     }
 
-    if (quest::get_data($client->AccountID() . "-season-1-participation-FNagafen")) {
+    if ($client->GetAccountBucket("season-1-participation-FNagafen")) {
         $participation_value += 10;
     }
 

--- a/plugins/cata_cheater_utils.pl
+++ b/plugins/cata_cheater_utils.pl
@@ -1,7 +1,7 @@
 sub GetSoulmark {
     my $client = shift;
 
-    my $soulmark = quest::get_data($client->AccountID() . "-CheaterFlag");
+    my $soulmark = $client->GetAccountBucket("CheaterFlag");
 
     return $soulmark;
 }

--- a/plugins/cata_donate_utils.pl
+++ b/plugins/cata_donate_utils.pl
@@ -43,8 +43,8 @@ sub AwardEOM {
     if (!$client->GetGM()) {
         quest::set_data($eom_award_log, (quest::get_data($eom_award_log) || 0) + $amount);
         
-        my $act_eom_total_key = $client->AccountID(). " -total-eom-awarded";
-        quest::set_data($act_eom_total_key, (quest::get_data($act_eom_total_key) || 0) + $amount);
+        my $act_eom_total_key = "total-eom-awarded";
+        $client->SetAccountBucket($act_eom_total_key, ($client->GetAccountBucket($act_eom_total_key) || 0) + $amount);
     }
 }
 
@@ -56,8 +56,8 @@ sub AwardEOMAuto {
     if (!$client->GetGM()) {
         quest::set_data($eom_award_log, (quest::get_data($eom_award_log) || 0) + $amount);
 
-        my $act_eom_total_key = $client->AccountID(). " -total-eom-awarded";
-        quest::set_data($act_eom_total_key, (quest::get_data($act_eom_total_key) || 0) + $amount);
+        my $act_eom_total_key = "total-eom-awarded";
+        $client->SetAccountBucket($act_eom_total_key, ($client->GetAccountBucket($act_eom_total_key) || 0) + $amount);
     }
 }
 

--- a/plugins/cata_event_utils.pl
+++ b/plugins/cata_event_utils.pl
@@ -9,8 +9,8 @@ sub DoEventRewards {
     }
 
     # Christmas 2024
-    my $nice_24 = quest::get_data($event_key . "xmas24_ret_nice") || 0;
-    my $nice_24_r = quest::get_data($event_key . "xmas24_ret_nice-rewarded") || 0;
+    my $nice_24 = $client->GetAccountBucket("xmas24_ret_nice") || 0;
+    my $nice_24_r = $client->GetAccountBucket("xmas24_ret_nice-rewarded") || 0;
 
     if (defined $nice_24 && $nice_24) {
         # Base Reward (val 1)
@@ -23,7 +23,7 @@ sub DoEventRewards {
             $client->SummonFixedItem(2827);
             $client->SummonFixedItem(2827);
 
-            quest::set_data($event_key . "xmas24_ret_nice-rewarded", max($nice_24_r, 1));
+            $client->SetAccountBucket("xmas24_ret_nice-rewarded", max($nice_24_r, 1));
         }
 
         # 50 or More
@@ -31,31 +31,31 @@ sub DoEventRewards {
             plugin::AddTitleFlag(209);
             if ($nice_24_r < 2) {
                 $client->SummonFixedItem(2004041);
-                quest::set_data($event_key . "xmas24_ret_nice-rewarded", max($nice_24_r, 2));
+                $client->SetAccountBucket("xmas24_ret_nice-rewarded", max($nice_24_r, 2));
             }           
         }
 
         # Top 100
         if ($nice_24 == 3 && $nice_24_r < 3) {
             $client->SummonFixedItem(66314);
-            quest::set_data($event_key . "xmas24_ret_nice-rewarded", max($nice_24_r, 3));
+            $client->SetAccountBucket("xmas24_ret_nice-rewarded", max($nice_24_r, 3));
         }
 
         # Top 50
         if ($nice_24 == 4 && $nice_24_r < 4) {
             $client->SummonFixedItem(1066314);
-            quest::set_data($event_key . "xmas24_ret_nice-rewarded", max($nice_24_r, 4));
+            $client->SetAccountBucket("xmas24_ret_nice-rewarded", max($nice_24_r, 4));
         }
 
         # Top 10
         if ($nice_24 == 5 && $nice_24_r < 5) {
             $client->SummonFixedItem(2066314);
-            quest::set_data($event_key . "xmas24_ret_nice-rewarded", max($nice_24_r, 5));
+            $client->SetAccountBucket("xmas24_ret_nice-rewarded", max($nice_24_r, 5));
         }
     }
     
-    my $destroyed = quest::get_data($client->AccountID() . "-ess-items-destroyed") || 0;
-    my $opened    = quest::get_data($client->AccountID() . "-ess-items-opened") || 0;
+    my $destroyed = $client->GetAccountBucket("ess-items-destroyed") || 0;
+    my $opened    = $client->GetAccountBucket("ess-items-opened") || 0;
     if ($opened || $destroyed) {
         plugin::AddTitleFlag(210);
     }

--- a/plugins/cata_progression_utils.pl
+++ b/plugins/cata_progression_utils.pl
@@ -364,7 +364,7 @@ sub SetSubflag {
             plugin::BlueText("Your memories gain sudden, sharp focus. You see the path forward.");
 
             if (plugin::IsSeasonal($client)) {
-                quest::set_data($client->AccountID() . "-progression-title-$stage", 1);
+                $client->SetAccountBucket("progression-title-$stage", 1);
             }
 
             if ($stage eq 'SoV') {
@@ -662,7 +662,7 @@ sub ConvertFlags {
     my $client = shift;
     
     # Old Flag Data
-    $expansion = quest::get_data($client->AccountID() . "-kunark-flag") || 0;
+    $expansion = $client->GetAccountBucket("kunark-flag") || 0;
 
     if ($expansion && !plugin::IsSeasonal($client)) {
         # Kunark
@@ -755,7 +755,7 @@ sub ConvertFlags {
 
         # Gates of Discord
         if (!is_stage_complete($client, 'GoD')) {
-            if ($expansion >= 20 || quest::get_data($client->AccountID() . "-saryrn-flag") || quest::get_data($client->AccountID() . "-quarm-kill")) {
+            if ($expansion >= 20 || $client->GetAccountBucket("saryrn-flag") || $client->GetAccountBucket("quarm-kill")) {
                 SetSubflag($client, 'GoD', 'Saryrn', 1);
             }
         }
@@ -800,42 +800,41 @@ sub delete_all_flags {
 
     # Go through each flag and delete it
     foreach my $flag_suffix (keys %flags_to_delete) {
-        my $key = $client->AccountID() . $flag_suffix;
-        quest::delete_data($key);  # Assuming quest::delete_data is the correct method to remove data
+        $client->DeleteAccountBucket($flag_suffix);
     }
 }
 
 
 sub UpdateRaceClassLocks {
     my $client = shift;
-    my $account_progression = quest::get_data($client->AccountID() . "-account-progression") || 0;
+    my $account_progression = $client->GetAccountBucket("account-progression") || 0;
 
     if ($account_progression < 1 && is_stage_complete($client, 'RoK')) {
-        quest::set_data($client->AccountID() . "-account-progression", 1);
+        $client->SetAccountBucket("account-progression", 1);
     }
 
     if ($account_progression < 2 && is_stage_complete($client, 'SoV')) {
-        quest::set_data($client->AccountID() . "-account-progression", 2);
+        $client->SetAccountBucket("account-progression", 2);
     }
 
     if ($account_progression < 3 && is_stage_complete($client, 'SoL')) {
-        quest::set_data($client->AccountID() . "-account-progression", 3);
+        $client->SetAccountBucket("account-progression", 3);
     }
 
     if ($account_progression < 4 && is_stage_complete($client, 'PoP')) {
-        quest::set_data($client->AccountID() . "-account-progression", 4);
+        $client->SetAccountBucket("account-progression", 4);
     }
 
     if ($account_progression < 5 && is_stage_complete($client, 'GoD')) {
-        quest::set_data($client->AccountID() . "-account-progression", 5);
+        $client->SetAccountBucket("account-progression", 5);
     }
 
     if ($account_progression < 6 && is_stage_complete($client, 'OoW')) {
-        quest::set_data($client->AccountID() . "-account-progression", 6);
+        $client->SetAccountBucket("account-progression", 6);
     }
 
     if ($account_progression < 7 && is_stage_complete($client, 'DoN')) {
-        quest::set_data($client->AccountID() . "-account-progression", 7);
+        $client->SetAccountBucket("account-progression", 7);
     }
 }
 

--- a/plugins/cata_progression_utils.pl
+++ b/plugins/cata_progression_utils.pl
@@ -653,7 +653,8 @@ sub UpdateCharMaxLevel
     }
 
     if (($client->GetBucket("CharMaxLevel") || 0) != $CharMaxLevel) {
-        $client->SetBucket("CharMaxlevel", $CharMaxLevel);        
+        # why is this set to the wrong case ?
+        $client->SetBucket("CharMaxLevel", $CharMaxLevel);        
         plugin::YellowText("Your Level Cap has been set to $CharMaxLevel.");
     }
 }

--- a/plugins/cata_progression_utils.pl
+++ b/plugins/cata_progression_utils.pl
@@ -889,19 +889,19 @@ sub GetProgressFlag {
 
     if ($seasonal && $season_id) {
         # Get the Serialized account flag
-        my $account_flag = quest::get_data($client->AccountID() . "-season-$season_id-progress-flag-$stage");
+        my $account_flag = $client->GetAccountBucket("season-$season_id-progress-flag-$stage");
         my $character_flag = $client->GetBucket("progress-flag-$stage");
 
         if (length($character_flag) > length($account_flag)) {  
             quest::debug("Adapting Character Seasonal flag.");
             $account_flag = $character_flag;
-            quest::set_data($client->AccountID() . "-season-$season_id-progress-flag-$stage", $character_flag);           
+            $client->SetAccountBucket("season-$season_id-progress-flag-$stage", $character_flag);           
         }
 
 
         return $account_flag;        
     } else {
-        return quest::get_data($client->AccountID() . "-progress-flag-$stage");
+        return $client->SetAccountBucket("progress-flag-$stage");
     }
 }
 

--- a/plugins/cata_progression_utils.pl
+++ b/plugins/cata_progression_utils.pl
@@ -898,10 +898,9 @@ sub GetProgressFlag {
             $client->SetAccountBucket("season-$season_id-progress-flag-$stage", $character_flag);           
         }
 
-
         return $account_flag;        
     } else {
-        return $client->SetAccountBucket("progress-flag-$stage");
+        return $client->GetAccountBucket("progress-flag-$stage");
     }
 }
 
@@ -912,16 +911,16 @@ sub SetProgressFlag {
 
     if ($seasonal && $season_id) {
         # Set the Serialized account flag for the current season
-        quest::set_data($client->AccountID() . "-season-$season_id-progress-flag-$stage", $flag_value);
+        $client->SetAccountBucket("season-$season_id-progress-flag-$stage", $flag_value);
 
-        my $regular_flag = quest::get_data($client->AccountID() . "-progress-flag-$stage");
+        my $regular_flag = $client->GetAccountBucket("progress-flag-$stage");
 
         if (length($flag_value) > length ($regular_flag)) {
             # also set the regular flag
-            quest::set_data($client->AccountID() . "-progress-flag-$stage", $flag_value);
+            $client->SetAccountBucket("progress-flag-$stage", $flag_value);
         }
     } else {
         # Set the regular progress flag
-        quest::set_data($client->AccountID() . "-progress-flag-$stage", $flag_value);
+        $client->SetAccountBucket("progress-flag-$stage", $flag_value);
     }
 }

--- a/plugins/cata_seasonal_utils.pl
+++ b/plugins/cata_seasonal_utils.pl
@@ -35,8 +35,8 @@ sub AwardSeasonalItems
 
     if (IsSeasonal($client)) {
         # Set basic account reward entitlement
-        if (!quest::get_data($client->AccountID() . "-season-1-entitlement")) {
-            quest::set_data($client->AccountID() . "-season-1-entitlement", "1");
+        if (!$client->GetAccountBucket("season-1-entitlement")) {
+            $client->SetAccountBucket("season-1-entitlement", "1");
         }
 
         if (!plugin::check_hasitem($client, $portable_hole)) {
@@ -53,34 +53,34 @@ sub RegisterSeasonalLogin {
 
     if ($client->IsSeasonal()) {
         #login tracker        
-        my $last_date = quest::get_data($client->AccountID() . "-season-1-date-flag") || 0;
+        my $last_date = $client->GetAccountBucket("season-1-date-flag") || 0;
         my ($sec, $min, $hour, $day, $mon, $year) = localtime();
         $year += 1900; # Adjust year to get the current year
         $mon++;
 
         if ($last_date ne "$day-$mon-$year") {
-            quest::set_data($client->AccountID() . "-season-1-date-flag", "$day-$mon-$year");
-            quest::set_data($client->AccountID() . "-season-1-participation", (quest::get_data($client->AccountID() . "-season-1-participation") || 0) + 1);
+            $client->SetAccountBucket("season-1-date-flag", "$day-$mon-$year");
+            $client->SetAccountBucket("season-1-participation", ($client->GetAccountBucket("season-1-participation") || 0) + 1);
         }
 
-        if (!quest::get_data($client->AccountID() . "-season-1-participation-RoK") && plugin::is_stage_complete($client, 'RoK')) {
-            quest::set_data($client->AccountID() . "-season-1-participation-RoK", 1);
+        if (!$client->GetAccountBucket("season-1-participation-RoK") && plugin::is_stage_complete($client, 'RoK')) {
+            $client->SetAccountBucket("season-1-participation-RoK", 1);
         }
 
-        if (!quest::get_data($client->AccountID() . "-season-1-participation-SoV") && plugin::is_stage_complete($client, 'SoV')) {
-            quest::set_data($client->AccountID() . "-season-1-participation-SoV", 1);
+        if (!$client->GetAccountBucket("season-1-participation-SoV") && plugin::is_stage_complete($client, 'SoV')) {
+            $client->SetAccountBucket("season-1-participation-SoV", 1);
         }
 
-        if (!quest::get_data($client->AccountID() . "-season-1-participation-SoL") && plugin::is_stage_complete($client, 'SoL')) {
-            quest::set_data($client->AccountID() . "-season-1-participation-SoL", 1);
+        if (!$client->GetAccountBucket("season-1-participation-SoL") && plugin::is_stage_complete($client, 'SoL')) {
+            $client->SetAccountBucket("season-1-participation-SoL", 1);
         } 
         
-        if (!quest::get_data($client->AccountID() . "-season-1-participation-PoP") && plugin::is_stage_complete($client, 'PoP')) {
-            quest::set_data($client->AccountID() . "-season-1-participation-PoP", 1);
+        if (!$client->GetAccountBucket("season-1-participation-PoP") && plugin::is_stage_complete($client, 'PoP')) {
+            $client->SetAccountBucket("season-1-participation-PoP", 1);
         } 
 
-        if (!quest::get_data($client->AccountID() . "-season-1-participation-FNagafen") && plugin::is_stage_complete($client, 'FNagafen')) {
-            quest::set_data($client->AccountID() . "-season-1-participation-FNagafen", 1);
+        if (!$client->GetAccountBucket("season-1-participation-FNagafen") && plugin::is_stage_complete($client, 'FNagafen')) {
+            $client->SetAccountBucket("season-1-participation-FNagafen", 1);
         }
     }
 }

--- a/plugins/cata_title_utils.pl
+++ b/plugins/cata_title_utils.pl
@@ -10,7 +10,7 @@ sub AddTitleFlag {
     my $client = shift || plugin::val('$client');
 
     # Retrieve and deserialize the account and character title lists
-    my @account_titles = plugin::DeserializeList(quest::get_data($client->AccountID() . "-titles-unlocked"));
+    my @account_titles = plugin::DeserializeList($client->GetAccountBucket("titles-unlocked"));
     my @character_titles = plugin::DeserializeList($client->GetBucket("titles-unlocked"));
 
     # Add the new title ID to both lists if it is not already present
@@ -22,7 +22,7 @@ sub AddTitleFlag {
     my $serialized_character_titles = plugin::SerializeList(@character_titles);
 
     # Store the updated lists
-    quest::set_data($client->AccountID() . "-titles-unlocked", $serialized_account_titles);
+    $client->SetAccountBucket("titles-unlocked", $serialized_account_titles);
     $client->SetBucket("titles-unlocked", $serialized_character_titles);
 
     EnableTitles($client);
@@ -33,7 +33,7 @@ sub EnableTitles {
     my $new_title = undef;
     
     # Retrieve and deserialize the account and character title lists
-    my @account_titles = plugin::DeserializeList(quest::get_data($client->AccountID() . "-titles-unlocked"));
+    my @account_titles = plugin::DeserializeList($client->GetAccountBucket("titles-unlocked"));
     my @character_titles = plugin::DeserializeList($client->GetBucket("titles-unlocked"));
 
     if (!plugin::IsSeasonal($client)) {

--- a/plugins/cata_wp_utils.pl
+++ b/plugins/cata_wp_utils.pl
@@ -247,13 +247,13 @@ sub AddWaypoint {
 
     if ($client) {
         if (plugin::is_eligible_for_zone($client, $waypoint, 0)) {
-            my %account_data = map { $_ => 1 } split(',', quest::get_data("Waypoints-" . $client->AccountID()));
+            my %account_data = map { $_ => 1 } split(',', $client->GetAccountBucket("Waypoints"));
             my %character_data = map { $_ => 1 } split(',', $client->GetBucket("Waypoints"));        
 
             if (exists $waypoints{$waypoint}) {
                 if (!exists $account_data{$waypoint}) {
                     $account_data{$waypoint} = 1;
-                    quest::set_data("Waypoints-" . $client->AccountID(), join(',', keys %account_data));
+                    $client->GetAccountBucket("Waypoints"), join(',', keys %account_data));
                     $return_feedback = 1;
                 }
 
@@ -306,7 +306,7 @@ sub GetWaypoints {
     my %return;
 
     if ($client) {
-        %data = map { $_ => 1 } split(',', quest::get_data("Waypoints-" . $client->AccountID()));
+        %data = map { $_ => 1 } split(',', $client->GetAccountBucket("Waypoints"));
 
         foreach my $key (keys %waypoints) {
             if (exists $data{$key} &&
@@ -369,7 +369,7 @@ sub GetWaypointCapturePattern {
     my @eligible_keys;  # Array to store the keys for the regex pattern
 
     if ($client) {
-        %data = map { $_ => 1 } split(',', quest::get_data("Waypoints-" . $client->AccountID()));
+        %data = map { $_ => 1 } split(',', $client->GetAccountBucket("Waypoints"));
 
         # Get race-specific waypoints for the client's base race
         my $race_specific_waypoints = GetRaceSpecificWaypoint($client->GetBaseRace());
@@ -418,7 +418,7 @@ sub GetWaypoint {
         # Check if the client is eligible for this waypoint
         if (plugin::is_eligible_for_zone($client, $shortname, 0)) {
             # Check if the waypoint is attuned for the client or is one of the race-specific waypoints
-            my %attuned_waypoints = map { $_ => 1 } split(',', quest::get_data("Waypoints-" . $client->AccountID()));
+            my %attuned_waypoints = map { $_ => 1 } split(',', $client->GetAccountBucket("Waypoints"));
             if (exists $attuned_waypoints{$shortname} || grep { $_ eq $shortname } @$race_specific_waypoints) {
                 return $waypoints{$shortname};  # Return the array reference for the waypoint
             }

--- a/plugins/cata_wp_utils.pl
+++ b/plugins/cata_wp_utils.pl
@@ -113,11 +113,11 @@ my %waypoints = (
 
 sub AwardBonusUnlocks {
     my $client = plugin::val('$client');
-    my $eligible = quest::get_data($client->AccountID() . "-TL-Account-A") ||
-                   quest::get_data($client->AccountID() . "-TL-Account-O") ||
-                   quest::get_data($client->AccountID() . "-TL-Account-F") ||
-                   quest::get_data($client->AccountID() . "-TL-Account-K") ||
-                   quest::get_data($client->AccountID() . "-TL-Account-V");
+    my $eligible = $client->GetAccountBucket("TL-Account-A") ||
+                   $client->GetAccountBucket("TL-Account-O") ||
+                   $client->GetAccountBucket("TL-Account-F") ||
+                   $client->GetAccountBucket("TL-Account-K") ||
+                   $client->GetAccountBucket("TL-Account-V");
 
     if ($eligible && !$client->IsSeasonal() && !$client->IsHardcore() && !plugin::IsTHJ()) {
         AddWaypoint('qeynos2');


### PR DESCRIPTION
This PR migrates legacy databuckets that generate hundreds of queries per character every time they zone.

This will convert legacy keys such as `Waypoints-account_id` to just `Waypoints` with the `account_id` automatically updated in the data_buckets table.

This will yield only 2 queries when a character loads into a zone versus literally hundreds.

**Backup table before running queries**

**Conversion SQL**

```sql

-- Most things
UPDATE `data_buckets`
SET
  account_id = CAST(SUBSTRING_INDEX(`key`, '-', 1) AS UNSIGNED),
  `key` = SUBSTRING(`key`, LOCATE('-', `key`) + 1)
WHERE
	`key` LIKE '%-ess-items-opened' 
	OR `key` LIKE '%-ess-items-destroyed'
	OR `key` LIKE '%-xmas24_ret_nice'
	OR `key` LIKE '%-xmas24_ret_nice-rewarded'
	OR `key` LIKE '%-progress-flag-%'
	OR `key` LIKE '%CheaterFlag%'
	OR `key` LIKE '%-WarpCount%'
	OR `key` LIKE '%-titles-unlocked'
	OR `key` LIKE '%-group-ports-enabled'
	OR `key` LIKE '%-ess-items-returned'
;

-- Waypoints
UPDATE `data_buckets`
SET
  account_id = CAST(SUBSTRING_INDEX(`key`, '-', -1) AS UNSIGNED),
  `key` = LEFT(`key`, LENGTH(`key`) - LENGTH(SUBSTRING_INDEX(`key`, '-', -1)) - 1)
WHERE `key` LIKE 'Waypoints-%';

-- EOM
UPDATE `data_buckets`
SET
  account_id = CAST(SUBSTRING_INDEX(TRIM(`key`), ' ', 1) AS UNSIGNED),
  `key` = SUBSTRING(SUBSTRING_INDEX(TRIM(`key`), ' ', -1), 2)
WHERE `key` LIKE '% -total-eom-awarded';

UPDATE `data_buckets` SET `key` = 'total-eom-awarded' WHERE `key` = '-total-eom-awarded';
```

**Convert Mis-Cased Max Level**

```sql
update data_buckets set `key` = 'CharMaxLevel' WHERE `key` = 'CharMaxlevel';
```

**Cleanup Flags**

```sql
-- Delete old kill flags
DELETE FROM `data_buckets` WHERE `key` LIKE '%-kill-count%';

-- Delete airplane flags with no expiry
DELETE FROM `data_buckets` WHERE `key` LIKE 'airplane-sirran-%' AND `expires` = 0;

-- These account EOM event scale keys look unused
DELETE FROM `data_buckets` WHERE `key` LIKE '%-eom-event-scale';
````

**Validation Query**

Used to check to see what else is left in the table that may not have been converted.

```sql
select * from data_buckets WHERE
	`key` NOT LIKE '%-ess-items-opened' 
	OR `key` NOT LIKE '%-ess-items-destroyed'
	OR `key` NOT LIKE '%-xmas24_ret_nice'
	OR `key` NOT LIKE '%-xmas24_ret_nice-rewarded'
	OR `key` NOT LIKE '%-progress-flag-%'
	OR `key` NOT LIKE '%CheaterFlag%'
	OR `key` NOT LIKE '%-WarpCount%'
	OR `key` NOT LIKE '%-titles-unlocked'
	OR `key` NOT LIKE '%kill-count%'
	OR `key` NOT LIKE '%Waypoints%'
	OR `key` NOT LIKE '%total-eom-awarded%'
	OR `key` NOT LIKE '%group-ports%'
	OR `key` NOT LIKE '%-ess-items-returned'
	GROUP by `key`;
```

**Example of Logging Into a Zone (Before)**

```
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 0 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = 'CharMaxLevel' LIMIT 1 -- (0 rows returned) (0.000070s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase DELETE FROM data_buckets WHERE character_id = 0 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = '0-dev-tools-disabled' -- (0 rows affected) (0.000170s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT `value` FROM `data_buckets` WHERE `key` = 'GestaltClasses' AND `character_id` = 43458 -- (1 row returned) (0.000014s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE account_id IN (43458) AND (`expires` > 1744178493 OR `expires` = 0) -- (0 rows returned) (0.000088s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE character_id IN (43458) AND (`expires` > 1744178493 OR `expires` = 0) -- (103 rows returned) (0.000203s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 43458 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = 'CharMaxLevel' LIMIT 1 -- (1 row returned) (0.000014s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT c.`id`, c.`name`, c.`class`, c.`level`, c.`last_login`, c.`zone_id`, g.`guild_id`, g.`rank`, g.`tribute_enable`, g.`total_tribute`, g.`last_tribute`, g.`banker`, g.`public_note`, g.`alt`, g.`online`, db.`value` AS `class_bitmask`  FROM `character_data` AS c  LEFT JOIN `guild_members` AS g ON c.`id` = g.`char_id`  LEFT JOIN `data_buckets` AS db ON c.`id` = db.`character_id` AND db.`key` = 'GestaltClasses'  WHERE c.id=43458 AND c.deleted_at IS NULL -- (1 row returned) (0.000113s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 43458 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = 'attack_mode' LIMIT 1 -- (0 rows returned) (0.000035s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 0 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = '2454-dev-tools-disabled' LIMIT 1 -- (0 rows returned) (0.000015s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE character_id = 43458 AND `key` LIKE 'aaTimer_%%' -- (88 rows returned) (0.000123s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT c.`id`, c.`name`, c.`class`, c.`level`, c.`last_login`, c.`zone_id`, g.`guild_id`, g.`rank`, g.`tribute_enable`, g.`total_tribute`, g.`last_tribute`, g.`banker`, g.`public_note`, g.`alt`, g.`online`, db.`value` AS `class_bitmask`  FROM `character_data` AS c  LEFT JOIN `guild_members` AS g ON c.`id` = g.`char_id`  LEFT JOIN `data_buckets` AS db ON c.`id` = db.`character_id` AND db.`key` = 'GestaltClasses'  WHERE c.id=43458 AND c.deleted_at IS NULL -- (1 row returned) (0.000084s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT c.`id`, c.`name`, c.`class`, c.`level`, c.`last_login`, c.`zone_id`, g.`guild_id`, g.`rank`, g.`tribute_enable`, g.`total_tribute`, g.`last_tribute`, g.`banker`, g.`public_note`, g.`alt`, g.`online`, db.`value` AS `class_bitmask`  FROM `character_data` AS c  LEFT JOIN `guild_members` AS g ON c.`id` = g.`char_id`  LEFT JOIN `data_buckets` AS db ON c.`id` = db.`character_id` AND db.`key` = 'GestaltClasses'  WHERE g.guild_id=199 AND c.deleted_at IS NULL -- (65 rows returned) (0.001949s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 43458 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = 'flag-semaphore' LIMIT 1 -- (0 rows returned) (0.000035s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 0 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = '2454-titles-unlocked' LIMIT 1 -- (1 row returned) (0.000035s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 43458 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = 'CharMaxLevel' LIMIT 1 -- (1 row returned) (0.000030s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 43458 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = 'CharMaxLevel' LIMIT 1 -- (1 row returned) (0.000041s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 0 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = '2454-progress-flag-RoK' LIMIT 1 -- (0 rows returned) (0.000033s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 0 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = '2454-progress-flag-PoP' LIMIT 1 -- (0 rows returned) (0.000030s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 43458 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = 'CharMaxLevel' LIMIT 1 -- (1 row returned) (0.000029s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 0 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = '2454-event-xmas24_ret_nice' LIMIT 1 -- (0 rows returned) (0.000038s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 0 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = '2454-event-xmas24_ret_nice-rewarded' LIMIT 1 -- (0 rows returned) (0.000014s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 0 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = '2454-ess-items-destroyed' LIMIT 1 -- (0 rows returned) (0.000025s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 0 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = '2454-ess-items-opened' LIMIT 1 -- (0 rows returned) (0.000050s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 0 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = '2454-progress-flag-PoP' LIMIT 1 -- (0 rows returned) (0.000035s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 0 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = '2454-CheaterFlag' LIMIT 1 -- (0 rows returned) (0.000049s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 0 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = '2454-titles-unlocked' LIMIT 1 -- (1 row returned) (0.000033s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 43458 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = 'CharMaxLevel' LIMIT 1 -- (1 row returned) (0.000029s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 43458 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = 'CharMaxLevel' LIMIT 1 -- (1 row returned) (0.000027s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 0 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = '2454-progress-flag-RoK' LIMIT 1 -- (0 rows returned) (0.000030s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 0 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = '2454-progress-flag-PoP' LIMIT 1 -- (0 rows returned) (0.000029s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 43458 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = 'CharMaxLevel' LIMIT 1 -- (1 row returned) (0.000027s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 0 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = '2454-event-xmas24_ret_nice' LIMIT 1 -- (0 rows returned) (0.000041s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 0 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = '2454-event-xmas24_ret_nice-rewarded' LIMIT 1 -- (0 rows returned) (0.000031s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 0 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = '2454-ess-items-destroyed' LIMIT 1 -- (0 rows returned) (0.000031s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 0 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = '2454-ess-items-opened' LIMIT 1 -- (0 rows returned) (0.000031s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 0 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = '2454-progress-flag-PoP' LIMIT 1 -- (0 rows returned) (0.000019s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 0 AND account_id = 2454 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = 'event' LIMIT 1 -- (1 row returned) (0.000014s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 43458 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = 'PetNameChangesAllowed' LIMIT 1 -- (0 rows returned) (0.000018s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 43458 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = 'name_change_allowed' LIMIT 1 -- (0 rows returned) (0.000012s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT c.`id`, c.`name`, c.`class`, c.`level`, c.`last_login`, c.`zone_id`, g.`guild_id`, g.`rank`, g.`tribute_enable`, g.`total_tribute`, g.`last_tribute`, g.`banker`, g.`public_note`, g.`alt`, g.`online`, db.`value` AS `class_bitmask`  FROM `character_data` AS c  LEFT JOIN `guild_members` AS g ON c.`id` = g.`char_id`  LEFT JOIN `data_buckets` AS db ON c.`id` = db.`character_id` AND db.`key` = 'GestaltClasses'  WHERE c.id=43458 AND c.deleted_at IS NULL -- (1 row returned) (0.000192s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT c.`id`, c.`name`, c.`class`, c.`level`, c.`last_login`, c.`zone_id`, g.`guild_id`, g.`rank`, g.`tribute_enable`, g.`total_tribute`, g.`last_tribute`, g.`banker`, g.`public_note`, g.`alt`, g.`online`, db.`value` AS `class_bitmask`  FROM `character_data` AS c  LEFT JOIN `guild_members` AS g ON c.`id` = g.`char_id`  LEFT JOIN `data_buckets` AS db ON c.`id` = db.`character_id` AND db.`key` = 'GestaltClasses'  WHERE g.guild_id=199 AND c.deleted_at IS NULL -- (65 rows returned) (0.001866s)-- [bazaar] (The Bazaar) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT c.`id`, c.`name`, c.`class`, c.`level`, c.`last_login`, c.`zone_id`, g.`guild_id`, g.`rank`, g.`tribute_enable`, g.`total_tribute`, g.`last_tribute`, g.`banker`, g.`public_note`, g.`alt`, g.`online`, db.`value` AS `class_bitmask`  FROM `character_data` AS c  LEFT JOIN `guild_members` AS g ON c.`id` = g.`char_id`  LEFT JOIN `data_buckets` AS db ON c.`id` = db.`character_id` AND db.`key` = 'GestaltClasses'  WHERE c.id=43458 AND c.deleted_at IS NULL -- (1 row returned) (0.000034s)-- [bazaar] (The Bazaar) inst_id [0]
 World |   Query    | QueryDatabase SELECT c.`id`, c.`name`, c.`class`, c.`level`, c.`last_login`, c.`zone_id`, g.`guild_id`, g.`rank`, g.`tribute_enable`, g.`total_tribute`, g.`last_tribute`, g.`banker`, g.`public_note`, g.`alt`, g.`online`, db.`value` AS `class_bitmask`  FROM `character_data` AS c  LEFT JOIN `guild_members` AS g ON c.`id` = g.`char_id`  LEFT JOIN `data_buckets` AS db ON c.`id` = db.`character_id` AND db.`key` = 'GestaltClasses'  WHERE c.id=43458 AND c.deleted_at IS NULL -- (1 row returned) (0.000051s)
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE character_id = 43458 AND `key` LIKE 'aaTimer_%%' -- (88 rows returned) (0.000037s)-- [bazaar] (The Bazaar) inst_id [0]
```

**Other Thoughts**

Consider removing `plugin::CommonCharacterUpdate` from **ENTERZONE** and leaving it for **CONNECT**