### PR TITLE
[Performance] Cache POP Charm Scale Calc

### DIFF
--- a/global/items/CHRMPoPAccess.lua
+++ b/global/items/CHRMPoPAccess.lua
@@ -1,4 +1,21 @@
 function event_scale_calc(e)
+	local ent_var_key = "pop_charm_flag_count";
+	local ent_var_time = "pop_charm_flag_lastcalc";
+	local cache_expire_time = 600; -- 10 minutes
+	local now = os.time()
+
+	-- Check if cached value exists and is fresh
+	if e.owner:EntityVariableExists(ent_var_key) and e.owner:EntityVariableExists(ent_var_time) then
+		local last_calc = tonumber(e.owner:GetEntityVariable(ent_var_time)) or 0
+		if (now - last_calc) < cache_expire_time then
+			local cached_count = tonumber(e.owner:GetEntityVariable(ent_var_key)) or 0
+			eq.debug("returning cached pop_charm_flag_count " .. cached_count, 3)
+			e.self:SetScale(cached_count / 10);
+			return
+		end
+	end
+
+	-- Recalculate
 	local flags = {
 		["pop.flags.aerin"] = 1,
 		["pop.flags.askr"] = 4,
@@ -19,6 +36,12 @@ function event_scale_calc(e)
 			flag_count = flag_count + 1
 		end
 	end
+
+	eq.debug("Calculating new pop charm value " .. tostring(flag_count), 3)
+
+	-- Cache new result and timestamp
+	e.owner:SetEntityVariable(ent_var_key, tostring(flag_count))
+	e.owner:SetEntityVariable(ent_var_time, tostring(now))
 
 	e.self:SetScale(flag_count / 10);
 end


### PR DESCRIPTION
One of the most expensive things showing up on Bazaar profiles today is -

* For every tic (6 seconds) -
   * For every player that has a POP Charm -
      * We loop through 10 nested databucket values

This adds up substantially and shows up hot on profiles. There's some things we can do source side to mitigate some of this but for now an easy way is to cache these values and return the cached value in memory.

This PR calculates a cached value and re-uses it every 10 minutes.

**Testing**

![image](https://github.com/user-attachments/assets/a6b0058b-85c3-4e4b-9bab-e1cad9562b11)

**Profile**

![image](https://github.com/user-attachments/assets/f059656a-ab41-466e-8bfb-a89b4c7d30a2)
