### PR TITLE
Update ring_of_fire.lua -  Lower Event time

### DIFF
--- a/acrylia/encounters/ring_of_fire.lua
+++ b/acrylia/encounters/ring_of_fire.lua
@@ -74,32 +74,32 @@ function process_wave()
 	elseif round == 1 then
 		if wave < 10 then
 			spawn_trash(round);
-			return 120;
+			return 30;
 		else
 			spawn_boss(round);
 			round, wave = end_round(round, wave);
-			return 300;
+			return 120;
 		end
 	elseif round == 2 then
-		if wave < 7 or (wave > 7 and wave < 14) then
+		if wave < 5 or (wave > 5 and wave < 10) then
 			spawn_trash(round);
-			return 90;
-		elseif wave == 7 then
+			return 30;
+		elseif wave == 5 then
 			spawn_mini();
 			return 90;
 		else
 			spawn_boss(round);
 			round, wave = end_round(round, wave);
-			return 300;
+			return 120;
 		end
 	elseif round >= 3 and round <= 6 then
-		if wave == 20 then
+		if wave == 15 then
 			spawn_boss(round);
 			round, wave = end_round(round, wave);
-			return math.random(300, 500);
+			return math.random(120, 300);
 		elseif wave % 5 == 0 then
 			spawn_mini();
-			return 60;
+			return 90;
 		else
 			spawn_trash(round);
 			return 60;


### PR DESCRIPTION
With THJ Power spike and triple class, having these events last almost 3 hours to get to the end seems unreasonable. 
This change lowers the overall wave times, and total time for rounds.   Loses 1 mini boss spawn per round from round 3 - 6.
total event time is max of 71 minutes instead of ~165 mins, 2.7 hours

Rnd 1 =  6.5 mins instead of 23 mins
Rnd 2 = 7.5 mins instead of 27 mins
Rnd 3 - 6, MAX 19.5 mins / round instead of 28 mins.