### PR TITLE
GoD Progression

### DIFF
--- a/abysmal/Adsame_Leing.lua
+++ b/abysmal/Adsame_Leing.lua
@@ -2,9 +2,27 @@ function event_say(e)
 	if e.message:findi("Hail") then
 		e.self:Say("Hello.  I have a fair selection of leather armor, if you have need of such things.  I've also picked up a trinket or two from other travelers, though they didn't find them so valuable that they couldn't sell them to me,' Adsame smiles.");
 	end
+	if e.message:findi("assistance") then
+		e.other:Message(MT.NPCQuestSay, "Adsame Leing says 'Oh?  What can I help you in crafting?  A [".. eq.say_link("muramite needle") .. "] or perhaps some hynid hair [" .. eq.say_link("thread") .. "]?'")
+	end
+	if e.message:findi("muramite needle") then
+		e.self:Say("Hmm, a muramite needle you say?  A few adventurers passed through here recently and told me how to make one.  I do not think it will give me much trouble, but you'll need to get met the materials.  I'll need a Muramite Residue and three bone chips to make it.  I will charge you five thousand platinum coins for this service.")
+	end
+	if e.message:findi("thread") then
+		e.self:Say("Thread made from hynid hair is quite strong, but difficult to create.  If you can provide me with three hynid hair strands and a muramite needle, however, I should be able to produce what you need.  I'll be using some of my hard earned skills at tailoring, so I'll also ask for a sum of five thousand platinum coins as well.")
+	end
 end
 
 function event_trade(e)
 	local item_lib = require("items");
+	if item_lib.check_turn_in(e.trade, {item1 = 60179, item2 = 60179, item3 = 60179, item4 = 60187, platinum = 5000}) then
+	  e.other:Message(MT.NPCQuestSay, "Adsame Leing bows slightly as he takes the items from you, then works quickly to fashion some tough looking thread.  'Here you are my friend, good luck on your travels!'")
+	  e.other:SummonItem(60188)
+	end
+	if item_lib.check_turn_in(e.trade, {item1 = 13073, item2 = 13073, item3 = 13073, item4 = 60178, platinum = 5000}) then
+	  e.other:Message(MT.NPCQuestSay, "Adsame Leing bows slightly as he takes the items from you, then works quickly to create a sharp, rugged needle.  'Here you are my firend, good luck on your travels!'")
+	  e.other:SummonItem(60187)
+	end
+
 	item_lib.return_items(e.self, e.other, e.trade);
 end

--- a/abysmal/Kaleng.lua
+++ b/abysmal/Kaleng.lua
@@ -2,6 +2,12 @@ function event_say(e)
 	if e.message:findi("Hail") then
 		e.self:Say("You looking for protection?  I gots da best.  Hard shell for soft ".. e.other:GetRaceName() .." body.");
 	end
+	if e.message:findi("assistance") then
+		e.self:Say("You needs da smithin' help?  I gots you, friend.  I bet you needs da [" .. eq.say_link('Inferno Scepter') .. "] made.")
+	end
+	if e.message:findi("inferno scepter") then
+		e.self:Say("Yep, no problem, " .. e.other:GetCleanName() .. "! You bring da Blazin Torch, Flarestone, Flarin Coals, and Mold, and me payment of five thousand platinum, and I make you for you!")
+	end
 end
 
 function event_signal(e)
@@ -12,5 +18,9 @@ end
 
 function event_trade(e)
 	local item_lib = require("items");
+	if item_lib.check_turn_in(e.trade, {item1 = 60184, item2 = 60182, item3 = 60183, item4 = 60186, platinum = 5000}) then
+		e.other:Message(MT.NPCQuestSay, "Kaleng nudges you out of the way of the forge, then almost carelessly throws the items you've given him into it.  There is an explosion of flame as he hammers away, and in a short time, produces a fiery looking scepter.  He grins at you, 'Here you go, thanks for the monies!'")
+		e.other:SummonItem(60181)
+	end
 	item_lib.return_items(e.self, e.other, e.trade);
 end

--- a/barindu/#Apprentice_Udranda.lua
+++ b/barindu/#Apprentice_Udranda.lua
@@ -37,10 +37,10 @@ end
 
 function event_say(e)
   local vxed_flag = tonumber(e.other:GetAccountBucket('god.flags.vxed')) or 0
-  local tipt_flag = tonumber(e.other:GetAccountBucket('god.flags.tipt')) or 0
   local pool_flag = tonumber(e.other:GetAccountBucket('god.flags.pool')) or 0
-  local has_vxed_access = (vxed_flag == 2) -- sewers or rondo complete
-  local has_tipt_access = (tipt_flag == 2) -- has_permanent_vxed
+  local ferubi_flag = tonumber(e.other:GetAccountBucket('god.flags.ferubi')) or 0
+  local has_vxed_access = (pool_flag == 3 or ferubi_flag == 1) -- sewers or rondo complete
+  local has_tipt_access = (vxed_flag == 2) -- has_permanent_vxed
 
   local is_gm = (e.other:Admin() > 80 and e.other:GetGM())
 
@@ -49,7 +49,7 @@ function event_say(e)
     if e.other:HasClass(Class.PALADIN) and e.other:HasItem(69933) then -- Item: Seal of Enic
       e.other:Message(MT.NPCQuestSay, string.format("I heard you released Reiya from his tourture, %s. I have seen muramites gathering in Vxed and I fear this may have to do with Reiya and the creatures responsible. Go there now and investigate, Noble Knight.", e.other:GetCleanName()))
       create_expedition(e.other, paladin_epic)
-    elseif pool_flag == 2  then -- sewers progression dialogue
+    elseif pool_flag == 3  then -- sewers progression dialogue
       -- note: live dialogue is always here if finished sewers, checking tipt access flag here avoids this live "bug"
       e.other:Message(MT.NPCQuestSay, "Udranda looks around sheepishly.  'Greetings.  A messenger told me you would come.  I believe we owe you our thanks -- though I'm not sure allowing you to face the terror in the mountains is a reward.  I will have my stone worker allow you to pass through, but you must [" .. eq.say_link("take heed") .. "] first and be as quiet as you can.'")
     else

--- a/barindu/#Apprentice_Udranda.lua
+++ b/barindu/#Apprentice_Udranda.lua
@@ -39,8 +39,8 @@ function event_say(e)
   local vxed_flag = tonumber(e.other:GetAccountBucket('god.flags.vxed')) or 0
   local tipt_flag = tonumber(e.other:GetAccountBucket('god.flags.tipt')) or 0
   local pool_flag = tonumber(e.other:GetAccountBucket('god.flags.pool')) or 0
-  local has_vxed_access = (vxed_flag == 1) -- sewers or rondo complete
-  local has_tipt_access = (tipt_flag == 1) -- has_permanent_vxed
+  local has_vxed_access = (vxed_flag == 2) -- sewers or rondo complete
+  local has_tipt_access = (tipt_flag == 2) -- has_permanent_vxed
 
   local is_gm = (e.other:Admin() > 80 and e.other:GetGM())
 

--- a/barindu/#Apprentice_Udranda.lua
+++ b/barindu/#Apprentice_Udranda.lua
@@ -36,12 +36,11 @@ local function create_expedition(client, expedition_info)
 end
 
 function event_say(e)
-  local qglobals = eq.get_qglobals(e.other)
-  local has_vxed_access = (qglobals.god_vxed_access and qglobals.god_vxed_access == "1") -- sewers or rondo complete
-  local has_tipt_access = (qglobals.god_tipt_access and qglobals.god_tipt_access == "1") -- has_permanent_vxed
-
-  local sewers_flag = tonumber(eq.get_data(e.other:CharacterID() .. "-god_sewers")) or 0
-  eq.debug(string.format("sewers[%s] vxed_access[%s] tipt_access[%s]", sewers_flag, tostring(has_vxed_access), tostring(has_tipt_access)))
+  local vxed_flag = tonumber(e.other:GetAccountBucket('god.flags.vxed')) or 0
+  local tipt_flag = tonumber(e.other:GetAccountBucket('god.flags.tipt')) or 0
+  local pool_flag = tonumber(e.other:GetAccountBucket('god.flags.pool')) or 0
+  local has_vxed_access = (vxed_flag == 1) -- sewers or rondo complete
+  local has_tipt_access = (tipt_flag == 1) -- has_permanent_vxed
 
   local is_gm = (e.other:Admin() > 80 and e.other:GetGM())
 
@@ -50,22 +49,19 @@ function event_say(e)
     if e.other:HasClass(Class.PALADIN) and e.other:HasItem(69933) then -- Item: Seal of Enic
       e.other:Message(MT.NPCQuestSay, string.format("I heard you released Reiya from his tourture, %s. I have seen muramites gathering in Vxed and I fear this may have to do with Reiya and the creatures responsible. Go there now and investigate, Noble Knight.", e.other:GetCleanName()))
       create_expedition(e.other, paladin_epic)
-    elseif sewers_flag == 4 and not has_tipt_access then -- sewers progression dialogue
+    elseif pool_flag == 2  then -- sewers progression dialogue
       -- note: live dialogue is always here if finished sewers, checking tipt access flag here avoids this live "bug"
       e.other:Message(MT.NPCQuestSay, "Udranda looks around sheepishly.  'Greetings.  A messenger told me you would come.  I believe we owe you our thanks -- though I'm not sure allowing you to face the terror in the mountains is a reward.  I will have my stone worker allow you to pass through, but you must [" .. eq.say_link("take heed") .. "] first and be as quiet as you can.'")
     else
       e.other:Message(MT.NPCQuestSay, "Udranda tells you, 'Greetings.  I have a duty here to stand guard at the mountain pass and allow the Muramites to pass through by moving the rocks with my magic.'  Udranda looks around for anyone listening and whispers to you. 'If you want to go into [" .. eq.say_link("Tipt") .. "] or [" .. eq.say_link("Vxed") .. "] I will have my stone worker open the passage for you.  If you want to progress past the mountains, I would ask that you first prove your worth with High Priest Diru.'")
     end
   elseif e.message:findi("take heed") and not has_tipt_access then -- no longer responds to this after receiving permanent vxed completed flag
-    if sewers_flag == 4 or has_vxed_access then
-      e.other:Message(MT.NPCQuestSay, "Udranda tells you, 'Good.  There are many secrets I can't tell you right now for fear the Muramites might hear them, but you must do as I say and trust in me.  In the mountain pass, Vxed, you must seek out Stonespiritist Ekikoa.  He is my mentor and will help you in your quest to find passage to the peaks.  We have created a very unique magic that we will share with you, but you must speak with him.  It will all be clear to you when you find him.  Tell me when you are [" .. eq.say_link("ready to pass") .. "] through.  I cannot leave a way open for too long.'")
+    if has_vxed_access then
+      e.other:Message(MT.NPCQuestSay, "Udranda tells you, 'Good.  There are many secrets I can't tell you right now for fear the Muramites might hear them, but you must do as I say and trust in me.  In the mountain pass, Vxed, you must seek out Stonespiritist Ekikoa.  He is my mentor and will help you in your quest to find passage to the peaks.  We have created a very unique magic that we will share with you, but you must speak with him.  It will all be clear to you when you find him.  Please hurry, I cannot leave a way open for too long.'")
       create_expedition(e.other, vxed) -- no emote when creating here
     else -- same message as hailing without progression
       e.other:Message(MT.NPCQuestSay, "Udranda tells you, 'Greetings.  I have a duty here to stand guard at the mountain pass and allow the Muramites to pass through by moving the rocks with my magic.'  Udranda looks around for anyone listening and whispers to you. 'If you want to go into [" .. eq.say_link("Tipt") .. "] or [" .. eq.say_link("Vxed") .. "] I will have my stone worker open the passage for you.  If you want to progress past the mountains, I would ask that you first prove your worth with High Priest Diru.'")
     end
-  elseif e.message:findi("ready to pass") and not has_tipt_access then
-    -- only responds without permanent vxed flag, possibly old dialogue to request tipt that was removed
-    e.other:Message(MT.NPCQuestSay, "Udranda tells you, 'I cannot allow you to pass with your companions.  You seem heroic enough, but you must prove your worth to High Priest Diru and our stonespiritist in the Vxed mountain pass before I can allow you through.'")
   elseif e.message:findi("tipt") and (is_gm or has_tipt_access) then
     eq.get_entity_list():MessageClose(e.self, true, 100, MT.SayEcho, e.self:GetCleanName() .. " subtly commands her stone worker to open the passage for you before any invaders can take notice.")
     create_expedition(e.other, tipt)

--- a/barindu/#High_Priest_Diru_Riwirn.lua
+++ b/barindu/#High_Priest_Diru_Riwirn.lua
@@ -105,7 +105,7 @@ function event_say(e)
 	local vxed_flag = tonumber(e.other:GetAccountBucket("god.flags.vxed")) or 0
 	if vxed_flag < 1 then
 	  e.other:Message(MT.LightBlue, "You have gained a character flag!")
-          e.other:SetAccountBucket("god.flags.vxed", "1")
+          e.other:SetAccountBucket("god.flags.vxed", "2")
 	end
       else
         e.other:Message(MT.NPCQuestSay, "High Priest Diru looks at you, puzzled.  'I'm sorry, I don't understand what you have and have not done for me lately.")

--- a/barindu/#High_Priest_Diru_Riwirn.lua
+++ b/barindu/#High_Priest_Diru_Riwirn.lua
@@ -100,19 +100,16 @@ function event_say(e)
       elseif plant_flag == 3 and crem_flag == 3 and lair_flag == 3 and pool_flag == 0 then
         e.other:Message(MT.NPCQuestSay, "High Priest Diru tells you, 'Utandi, the map maker, should be in the sewers.  I must apologize for him in advance.  He is wonderful with his maps, but very timid.  Good luck and I hope that we can stand together, defiant against the invaders.'")
         create_sewer_expedition(e.other, sewers.snpool)
-      elseif plant_flag == 3 and crem_flag == 3 and lair_flag == 3 and pool_flag >= 2 then
+      elseif plant_flag == 3 and crem_flag == 3 and lair_flag == 3 and pool_flag == 2 then
         e.other:Message(MT.NPCQuestSay, "High Priest Diru tells you, 'You have done excellent work helping our tribe.  You and your kind are powerful and have done more for us than we expected, so I will reward you with the information you've been wanting.  In order to pass through the mountains, you must work with those who have the most sacred knowledge of our lands -- the master stonespiritists.  You will find an apprentice in Barindu, named Udranda.  She will grant you access to the mountain pass and then tell you what you must do.  Also, if you ever need to go back into the sewers for any reason, you can ask Gamesh to show you the way through.  Good luck to you, and to us all.'")
-	local vxed_flag = tonumber(e.other:GetAccountBucket("god.flags.vxed")) or 0
-	if vxed_flag < 1 then
-	  e.other:Message(MT.LightBlue, "You have gained a character flag!")
-          e.other:SetAccountBucket("god.flags.vxed", "2")
-	end
+	e.other:Message(MT.LightBlue, "You have gained a character flag!")
+        e.other:SetAccountBucket("god.flags.plant", "3")
       else
         e.other:Message(MT.NPCQuestSay, "High Priest Diru looks at you, puzzled.  'I'm sorry, I don't understand what you have and have not done for me lately.")
 	eq.debug('Flags are in an impossible state.')
-end
       end
-   end
+    end
+  end
 end
 
 function event_trade(e)

--- a/barindu/#High_Priest_Diru_Riwirn.lua
+++ b/barindu/#High_Priest_Diru_Riwirn.lua
@@ -36,50 +36,83 @@ local function create_sewer_expedition(client, sewer)
 end
 
 function event_say(e)
-  local char_id = e.other:CharacterID()
-
-  local sewer_flag_key = string.format("%s-god_sewers", char_id)
-  local sewers_flag = tonumber(eq.get_data(sewer_flag_key)) or 0
-
-  local snplant_complete     = (eq.get_data(string.format("%s-god_snplant", char_id)) == "1")
-  local sncrematory_complete = (eq.get_data(string.format("%s-god_sncrematory", char_id)) == "1")
-  local snlair_complete      = (eq.get_data(string.format("%s-god_snlair", char_id)) == "1")
-  local snpool_complete      = (eq.get_data(string.format("%s-god_snpool", char_id)) == "1")
+  local sewers_flag = tonumber(e.other:GetAccountBucket("god.flags.sewers")) or 0
+  local plant_flag = tonumber(e.other:GetAccountBucket("god.flags.plant")) or 0
+  local crem_flag = tonumber(e.other:GetAccountBucket("god.flags.crematory")) or 0
+  local lair_flag = tonumber(e.other:GetAccountBucket("god.flags.lair")) or 0
+  local pool_flag = tonumber(e.other:GetAccountBucket("god.flags.pool")) or 0
 
   eq.debug(string.format("god_sewers[%s] snplant[%s] sncrematory[%s] snlair[%s] snpool[%s]",
-           sewers_flag, tostring(snplant_complete), tostring(sncrematory_complete), tostring(snlair_complete), tostring(snpool_complete)))
+           sewers_flag, plant_flag, crem_flag, lair_flag, pool_flag))
 
   if e.message:findi("hail") then
     if sewers_flag == 0 then
       e.other:Message(MT.NPCQuestSay, "High Priest Diru tells you, 'These are sad times.  Not only have the invaders taken away all that we own, but our own problems still occur.  If only there was someone willing to help our cause.  I beg of you, please, help us with all the problems going on in the sewers underneath this city.  They have become the breeding grounds for stonemites.  These nasty bugs get into everything.  They eat our stored food and our crops.  We need to terminate the source of the stonemites so that we will have enough food to survive.  The invaders do not provide enough for us, and we need these crops to live.  Please prepare and talk to me again when you are ready to help.'")
-      eq.set_data(sewer_flag_key, "1") -- preflag
-    elseif sewers_flag == 1 and not snplant_complete then
-      e.other:Message(MT.NPCQuestSay, "High Priest Diru tells you, 'Go find Ansharu.  He has been researching their behavior patterns, and will be able to tell you what needs to be done.  I hope that you will be able to help us out in these dire times.  Please head to the sewer plant and find the source of the stonemite infestation.  If you do this for us, I will share with you how to pass through the mountains and up to the temples created by the trusik, our exiled kin.'")
-      create_sewer_expedition(e.other, sewers.snplant)
+      e.other:SetAccountBucket("god.flags.sewers", "1")
     elseif sewers_flag == 1 then
-      e.other:Message(MT.NPCQuestSay, "High Priest Diru tells you, 'You defeated the Kayserops?  I had my doubts about your kind, but it seems we can trust you with our affairs.  I will reveal to you how to pass through the mountains, but first you will need to help us with another problem, a sacred one.  In the past, Taelosians were sent to the crematory on death.  Here their souls were separated from their bodies and imbued into the Spiritstone.  However, since the invaders came, those that had expected to be part of the Spiritstone were robbed of that right as they died with no one able to conduct the final ceremony.  They are angry because they must spend eternity in limbo, looking for a way to become a part of the Spiritstone.  We must set their spirits at ease.  Please talk to me again when you are ready and I will give you more information on the matter.'")
-      eq.set_data(sewer_flag_key, "2")
-    elseif sewers_flag == 2 and not sncrematory_complete then
-      e.other:Message(MT.NPCQuestSay, "High Priest Diru tells you, 'I know that you can do this for us.  I have seen your action in this city and have heard of them on the rest of the continent.  Please set the spirits of the fallen at ease.  Seek out a way to into the crematory, find the remains of Ngozi, Mabiki, Talokoi, and Yogundi.   Take the remains into the furnace and their spirits will present themselves.  All will become clear when the time has come.'")
-      create_sewer_expedition(e.other, sewers.sncrematory)
-    elseif sewers_flag == 2 then
-      e.other:Message(MT.NPCQuestSay, "High Priest Diru tells you, 'Your reputation precedes you.  I have heard of your exploits in the crematory.  It warms my heart to know that those spirits will now be at ease after a lifetime of misery.  I was going to tell you of the way through the mountains, but an emergency has come up.  You must hurry back down into the sewers.  It seems there was one who thought that he could get the purification devices working again.  He has gone down to fix whatever was wrong with it.  He should have returned by now, but no one has heard from him.  After you have prepared come talk to me again, and I will give you more information on the matter.'")
-      eq.set_data(sewer_flag_key, "3")
-    elseif sewers_flag == 3 and not snlair_complete then
-      e.other:Message(MT.NPCQuestSay, "High Priest Diru tells you, 'Our sewer system was an integral part of the city before the great explosion. After the sewer system was deserted by most Taelosians, many of the processes that occurred below the city ceased to work.  In the sewers, many insects, animals, and other slimy diseased creatures thrive.  Take this seal.  I know that Alej is very timid and may think you are there to harm him unless he sees something familiar from you.  Please be careful while you\'re down there and be on the look out for cave-ins.'")
-      e.other:SummonItem(68298) -- Item: Seal of the Nihil High Priest
-      create_sewer_expedition(e.other, sewers.snlair)
-    elseif sewers_flag == 3 then
-      e.other:Message(MT.NPCQuestSay, "High Priest Diru tells you, 'Thank you so much for finding our fallen.  You will be happy to know that he has returned safely for a moment, but insisted on going back down to check on the status of things.  He really wants to try and make all of that machinery work again to help purify all the waters.  As promised, I will tell you how to get through the mountain pass safely.  To get through you will need to... talk to the city map maker.  The only issue with this is that he is in the sewers.  He was banished there by the Muramites.  If you go to the area of the sewers that has the large pool, you should be able to find him.  Talk to me again when you are ready and I will give you more information.'")
-      eq.set_data(sewer_flag_key, "4")
-    elseif sewers_flag == 4 and not snpool_complete then
-      e.other:Message(MT.NPCQuestSay, "High Priest Diru tells you, 'Utandi, the map maker, should be in the sewers.  I must apologize for him in advance.  He is wonderful with his maps, but very timid.  Good luck and I hope that we can stand together, defiant against the invaders.'")
-      create_sewer_expedition(e.other, sewers.snpool)
-    elseif sewers_flag >= 4 then
-      e.other:Message(MT.NPCQuestSay, "High Priest Diru tells you, 'You have done excellent work helping our tribe.  You and your kind are powerful and have done more for us than we expected, so I will reward you with the information you've been wanting.  In order to pass through the mountains, you must work with those who have the most sacred knowledge of our lands -- the master stonespiritists.  You will find an apprentice in Barindu, named Udranda.  She will grant you access to the mountain pass and then tell you what you must do.  Also, if you ever need to go back into the sewers for any reason, you can ask Gamesh to show you the way through.  Good luck to you, and to us all.'")
-      eq.set_global("god_vxed_access", "1", 5, "F")	-- finished with sewers (had to talk to priest otherwise vxed was a "temporary" flag)
-    end
-  end
+      -- Handle Back Flags
+      if plant_flag == 1 then
+        e.other:Message(MT.NPCQuestSay, "High Priest Diru tells you, 'I've heard from Ansahru that you have already assisted him with the Kayserops.  Thank you for your assistance, but there is still more for you to do.")
+	e.other:Message(MT.LightBlue, "Your temporary flag has become a character flag!")
+	e.other:SetAccountBucket("god.flags.plant", "2")
+      end
+      if crem_flag == 1 then
+	e.other:Message(MT.NPCQuestSay, "High Priest Diru tells you, 'The spirits of our fallen have spoken with me that you have already released them.  Thank you for your assistance, but there is still more for you to do.")
+ 	e.other:Message(MT.LightBlue, "Your temporary flag has become a character flag!")
+        e.other:SetAccountBucket("god.flags.crematory", "2")
+      end
+      if lair_flag == 1 then
+	e.other:Message(MT.NPCQuestSay, "High Priest Diru tells you, 'Alej has informed me that you have already assisted him with finding his tools.  Thank you for your assistance, but there is still more for you to do.")
+	e.other:Message(MT.LightBlue, "Your temporary flag has become a character flag!")
+	e.other:SetAccountBucket("god.flags.lair", "2")
+      end
+      if pool_flag == 1 then
+	e.other:Message(MT.NPCQuestSay, "High Priest Diru tells you, 'Utandi has already told you how to access the mountains?  Excellent!  Thank you for your assistance, but there is still more for you to do.")
+	e.other:Message(MT.LightBlue, "Your temporary flag has become a character flag!")
+	e.other:SetAccountBucket("god.flags.pool", "2")
+      end
+  
+      plant_flag = tonumber(e.other:GetAccountBucket("god.flags.plant")) or 0
+      crem_flag = tonumber(e.other:GetAccountBucket("god.flags.crematory")) or 0
+      lair_flag = tonumber(e.other:GetAccountBucket("god.flags.lair")) or 0
+      pool_flag = tonumber(e.other:GetAccountBucket("god.flags.pool")) or 0
+      
+      -- Handle where to go next
+      if plant_flag == 0 then
+        e.other:Message(MT.NPCQuestSay, "High Priest Diru tells you, 'Go find Ansharu.  He has been researching their behavior patterns, and will be able to tell you what needs to be done.  I hope that you will be able to help us out in these dire times.  Please head to the sewer plant and find the source of the stonemite infestation.  If you do this for us, I will share with you how to pass through the mountains and up to the temples created by the trusik, our exiled kin.'")
+        create_sewer_expedition(e.other, sewers.snplant)
+      elseif plant_flag == 2 then
+        e.other:Message(MT.NPCQuestSay, "High Priest Diru tells you, 'You defeated the Kayserops?  I had my doubts about your kind, but it seems we can trust you with our affairs.  I will reveal to you how to pass through the mountains, but first you will need to help us with another problem, a sacred one.  In the past, Taelosians were sent to the crematory on death.  Here their souls were separated from their bodies and imbued into the Spiritstone.  However, since the invaders came, those that had expected to be part of the Spiritstone were robbed of that right as they died with no one able to conduct the final ceremony.  They are angry because they must spend eternity in limbo, looking for a way to become a part of the Spiritstone.  We must set their spirits at ease.  Please talk to me again when you are ready and I will give you more information on the matter.'")
+	e.other:SetAccountBucket("god.flags.plant", "3")
+      elseif plant_flag == 3 and crem_flag == 0 then
+      	e.other:Message(MT.NPCQuestSay, "High Priest Diru tells you, 'I know that you can do this for us.  I have seen your action in this city and have heard of them on the rest of the continent.  Please set the spirits of the fallen at ease.  Seek out a way to into the crematory, find the remains of Ngozi, Mabiki, Talokoi, and Yogundi.   Take the remains into the furnace and their spirits will present themselves.  All will become clear when the time has come.'")
+        create_sewer_expedition(e.other, sewers.sncrematory)
+      elseif plant_flag == 3 and crem_flag == 2 then
+        e.other:Message(MT.NPCQuestSay, "High Priest Diru tells you, 'Your reputation precedes you.  I have heard of your exploits in the crematory.  It warms my heart to know that those spirits will now be at ease after a lifetime of misery.  I was going to tell you of the way through the mountains, but an emergency has come up.  You must hurry back down into the sewers.  It seems there was one who thought that he could get the purification devices working again.  He has gone down to fix whatever was wrong with it.  He should have returned by now, but no one has heard from him.  After you have prepared come talk to me again, and I will give you more information on the matter.'")
+	e.other:SetAccountBucket("god.flags.crematory", "3")
+      elseif plant_flag == 3 and crem_flag == 3 and lair_flag == 0 then
+        e.other:Message(MT.NPCQuestSay, "High Priest Diru tells you, 'Our sewer system was an integral part of the city before the great explosion. After the sewer system was deserted by most Taelosians, many of the processes that occurred below the city ceased to work.  In the sewers, many insects, animals, and other slimy diseased creatures thrive.  Take this seal.  I know that Alej is very timid and may think you are there to harm him unless he sees something familiar from you.  Please be careful while you\'re down there and be on the look out for cave-ins.'")
+        e.other:SummonItem(68298) -- Item: Seal of the Nihil High Priest
+        create_sewer_expedition(e.other, sewers.snlair)
+      elseif plant_flag == 3 and crem_flag == 3 and lair_flag == 2 then
+        e.other:Message(MT.NPCQuestSay, "High Priest Diru tells you, 'Thank you so much for finding our fallen.  You will be happy to know that he has returned safely for a moment, but insisted on going back down to check on the status of things.  He really wants to try and make all of that machinery work again to help purify all the waters.  As promised, I will tell you how to get through the mountain pass safely.  To get through you will need to... talk to the city map maker.  The only issue with this is that he is in the sewers.  He was banished there by the Muramites.  If you go to the area of the sewers that has the large pool, you should be able to find him.  Talk to me again when you are ready and I will give you more information.'")
+        e.other:SetAccountBucket("god.flags.lair", "3")
+      elseif plant_flag == 3 and crem_flag == 3 and lair_flag == 3 and pool_flag == 0 then
+        e.other:Message(MT.NPCQuestSay, "High Priest Diru tells you, 'Utandi, the map maker, should be in the sewers.  I must apologize for him in advance.  He is wonderful with his maps, but very timid.  Good luck and I hope that we can stand together, defiant against the invaders.'")
+        create_sewer_expedition(e.other, sewers.snpool)
+      elseif plant_flag == 3 and crem_flag == 3 and lair_flag == 3 and pool_flag >= 2 then
+        e.other:Message(MT.NPCQuestSay, "High Priest Diru tells you, 'You have done excellent work helping our tribe.  You and your kind are powerful and have done more for us than we expected, so I will reward you with the information you've been wanting.  In order to pass through the mountains, you must work with those who have the most sacred knowledge of our lands -- the master stonespiritists.  You will find an apprentice in Barindu, named Udranda.  She will grant you access to the mountain pass and then tell you what you must do.  Also, if you ever need to go back into the sewers for any reason, you can ask Gamesh to show you the way through.  Good luck to you, and to us all.'")
+	local vxed_flag = tonumber(e.other:GetAccountBucket("god.flags.vxed")) or 0
+	if vxed_flag < 1 then
+	  e.other:Message(MT.LightBlue, "You have gained a character flag!")
+          e.other:SetAccountBucket("god.flags.vxed", "1")
+	end
+      else
+        e.other:Message(MT.NPCQuestSay, "High Priest Diru looks at you, puzzled.  'I'm sorry, I don't understand what you have and have not done for me lately.")
+	eq.debug('Flags are in an impossible state.')
+end
+      end
+   end
 end
 
 function event_trade(e)

--- a/barindu/Scribe_Gurru.lua
+++ b/barindu/Scribe_Gurru.lua
@@ -39,8 +39,12 @@ function event_say(e)
       convert_temp_flag(e.other, "god.flags.vxed", "Vxed")
     elseif has_vxed_flag and tipt_flag == 1 then
       convert_temp_flag(e.other, "god.flags.tipt", "Tipt")
-    elseif has_tipt_flag and kt_flag == 1 then
+    elseif has_tipt_flag and has_vxed_flag and kt_flag == 0 then
+      e.other:Message(MT.NPCQuestSay, "Scribe Guru says, 'I see you have helped Apprentice Udranda with navigating the mountains.  I will tell the High Priest of your deeds.  Be careful in the mountains, there is a reason we exiled the Trusik there...'")
+      e.other:Message(MT.LightBlue, "You have gained a character flag!")
       e.other:SetAccountBucket("god.flags.kt", "1")
+    elseif kt_flag > 0 then
+      e.other:Message(MT.NPCQuestSay, "Scribe Guru says, 'You have been a great help to the inhabitants of Barindu.  You should venture into the mountains and seek the temples there.  Please drive out these invaders from our land!")
     else
       e.other:Message(MT.NPCQuestSay, "Gurru tells you, 'I see that you have completed some deeds for our people and we appreciate it.  Before I can tell the High Priest of your work though, you will need to talk to him and finish some other tasks.'")
     end

--- a/barindu/Scribe_Gurru.lua
+++ b/barindu/Scribe_Gurru.lua
@@ -4,18 +4,8 @@ local function convert_temp_flag(client, flag_name, flag_msg)
   -- "temporary" messages when repeating expeditions even after made permanent.
   -- Just a quirk in their priority flag checks (they probably use a separate flag)
   client:Message(MT.NPCQuestSay, string.format("Gurru tells you, 'I see that you have helped your friends accomplish things in %s.  I will tell the High Priest of your deeds.  You should seek an audience with him and see if there is anything else that you can help us with.'", flag_msg))
-  eq.set_data(string.format("%s-%s", client:CharacterID(), flag_name), "1")
+  client:SetAccountBucket(flag_name, "2")
   client:Message(MT.Yellow, "Your temporary character flag has been converted into a permanent flag!")
-  eq.debug(string.format("Converted character [%s] temporary flag [%s] to permanent", client:GetName(), flag_name))
-end
-
-local function update_sewers_flag(char_id, minimum_flag)
-  local sewer_flag_key = string.format("%s-god_sewers", char_id)
-  local sewers_flag = tonumber(eq.get_data(sewer_flag_key)) or 0
-
-  if sewers_flag < minimum_flag then
-    eq.set_data(sewer_flag_key, tostring(minimum_flag))
-  end
 end
 
 function event_say(e)
@@ -24,40 +14,33 @@ function event_say(e)
   elseif e.message:findi("issues") then
     -- converts temporary flags into permanent flags if at right point in progression
     -- temporary flags are from completing expeditions with others outside progression
-    local qglobals = eq.get_qglobals(e.other)
-    local has_vxed_access = (qglobals.god_vxed_access and qglobals.god_vxed_access == "1") -- sewers or rondo complete
-    local has_tipt_access = (qglobals.god_tipt_access and qglobals.god_tipt_access == "1") -- has_permanent_vxed
+    local tipt_flag = tonumber(e.other:GetAccountBucket('god.flags.tipt')) or 0
+    local vxed_flag = tonumber(e.other:GetAccountBucket('god.flags.vxed')) or 0
+    local has_vxed_access = (vxed_flag == 2)
+    local has_tipt_access = (tipt_flag == 2)
 
-    local char_id = e.other:CharacterID()
-
-    local snplant     = eq.get_data(("%s-god_snplant"):format(char_id))
-    local sncrematory = eq.get_data(("%s-god_sncrematory"):format(char_id))
-    local snlair      = eq.get_data(("%s-god_snlair"):format(char_id))
-    local snpool      = eq.get_data(("%s-god_snpool"):format(char_id))
-    local vxed        = eq.get_data(("%s-god_vxed"):format(char_id))
-    local tipt        = eq.get_data(("%s-god_tipt"):format(char_id))
+    local sewers_flag = tonumber(e.other:GetAccountBucket('god.flags.sewers')) or 0
+    local plant_flag = tonumber(e.other:GetAccountBucket('god.flags.plant')) or 0
+    local lair_flag = tonumber(e.other:GetAccountBucket('god.flags.lair')) or 0
+    local crem_flag = tonumber(e.other:GetAccountBucket('god.flags.crematory')) or 0
+    local kt_flag = tonumber(e.other:GetAccountBucket('god.flag.kt')) or 0
 
     -- permanent flag for previous sewer indicates character is on that step
-    -- update main sewers flag for accurate dialogue (high priest hails not required)
 
-    if snplant == "T" then
-      convert_temp_flag(e.other, "god_snplant", "the Purifying Plant")
-      update_sewers_flag(char_id, 1)
-    elseif sncrematory == "T" and snplant == "1" then
-      convert_temp_flag(e.other, "god_sncrematory", "the Crematory")
-      update_sewers_flag(char_id, 2)
-    elseif snlair == "T" and sncrematory == "1" then
-      convert_temp_flag(e.other, "god_snlair", "the Lair of Trapped Ones")
-      update_sewers_flag(char_id, 3)
-    elseif snpool == "T" and snlair == "1" then
-      convert_temp_flag(e.other, "god_snpool", "the Pool of Sludge")
-      update_sewers_flag(char_id, 4)
-    elseif vxed == "T" and (snpool == "1" or has_vxed_access) then -- finished sewers or has rondo skip
-      convert_temp_flag(e.other, "god_vxed", "Vxed")
-      eq.set_global("god_tipt_access", "1", 5, "F")
-    elseif tipt == "T" and has_tipt_access then -- must have completed permanent vxed
-      convert_temp_flag(e.other, "god_tipt", "Tipt")
-      eq.set_global("god_kodtaz_access", "1", 5, "F")
+    if sewers_flag == 1 and plant_flag == 1 then
+      convert_temp_flag(e.other, "god.flags.plant", "the Purifying Plant")
+    elseif sewers_flag == 1 and plant_flag >= 2 and crem_flag == 1 then
+      convert_temp_flag(e.other, "god.flags.crematory", "the Crematory")
+    elseif sewers_flag == 1 and plant_flag >= 2 and crem_flag >= 2 and lair_flag == 1 then
+      convert_temp_flag(e.other, "god.flags.lair", "the Lair of Trapped Ones")
+    elseif sewers_flag == 1 and plant_flag >= 2 and crem_flag >= 2 and lair_flag >= 2 and pool_flag == 1 then
+      convert_temp_flag(e.other, "god.flags.pool", "the Pool of Sludge")
+    elseif sewers_flag == 1 and plant_flag >= 2 and crem_flag >= 2 and lair_flag >= 2 and pool_flag >= 2 and vxed_flag == 1 then
+      convert_temp_flag(e.other, "god.flags.vxed", "Vxed")
+    elseif has_vxed_flag and tipt_flag == 1 then
+      convert_temp_flag(e.other, "god.flags.tipt", "Tipt")
+    elseif has_tipt_flag and kt_flag == 1 then
+      e.other:SetAccountBucket("god.flags.kt", "1")
     else
       e.other:Message(MT.NPCQuestSay, "Gurru tells you, 'I see that you have completed some deeds for our people and we appreciate it.  Before I can tell the High Priest of your work though, you will need to talk to him and finish some other tasks.'")
     end

--- a/ferubi/#Smith-s_Spectral_Memory.lua
+++ b/ferubi/#Smith-s_Spectral_Memory.lua
@@ -5,12 +5,12 @@ end
 function event_say(e)
 local qglobals = eq.get_qglobals(e.other);
 	if(e.message:findi("hail")) then
-		if qglobals["bic_fer"] ~= nil and qglobals["bic_fer"] == "10" then
-			e.other:Message(MT.LightBlue, "You feel a chill surround your body as a voice enters your mind. 'Thank you for releasing me from an eternity of suffering. Now you must help the others on this continent whose fate I fear is much worse than mine. You must seek out Apprentice Udranda in Barindu. She can help you gain access to the temples beyond the mountain passes.");
+	  e.other:Message(MT.LightBlue, "You feel a chill surround your body as a voice enters your mind. 'Thank you for releasing me from an eternity of suffering. Now you must help the others on this continent whose fate I fear is much worse than mine. You must seek out Apprentice Udranda in Barindu. She can help you gain access to the temples beyond the mountain passes.");
+	if qglobals["bic_fer"] ~= nil and qglobals["bic_fer"] == "10" then
 			e.other:SummonItem(67526); -- Item: Rondo's Report
 			eq.set_global("bic_fer", "11", 5, "F");
 		end
-		eq.set_global("god_vxed_access", "1", 5, "F");
+		e.other:SetAccountBucket("god.flags.vxed", "2");
 		e.other:Message(MT.LightBlue, "You receive a character flag!");
 	end
 end

--- a/ferubi/#Smith-s_Spectral_Memory.lua
+++ b/ferubi/#Smith-s_Spectral_Memory.lua
@@ -10,7 +10,7 @@ local qglobals = eq.get_qglobals(e.other);
 			e.other:SummonItem(67526); -- Item: Rondo's Report
 			eq.set_global("bic_fer", "11", 5, "F");
 		end
-		e.other:SetAccountBucket("god.flags.vxed", "2");
+		e.other:SetAccountBucket("god.flags.ferubi", "1");
 		e.other:Message(MT.LightBlue, "You receive a character flag!");
 	end
 end

--- a/kodtaz/#Ageless_Relic_Protector.lua
+++ b/kodtaz/#Ageless_Relic_Protector.lua
@@ -1,6 +1,0 @@
-function event_death_complete(e)
-  if e.self:GetID() == 293222 or e.self:GetID() == 293223 then
-    eq.spawn2(29324,0,0,e.other:GetX() - 10, e.other:GetY(), e.other:GetZ(), e.other:GetHeading())
-    eq.spawn2(29325,0,0,e.other:GetX() + 10, e.other:GetY(), e.other:GetZ(), e.other:GetHeading())
-  end
-end

--- a/kodtaz/#Ageless_Relic_Protector.lua
+++ b/kodtaz/#Ageless_Relic_Protector.lua
@@ -1,0 +1,6 @@
+function event_death_complete(e)
+  if e.self:GetID() == 293222 or e.self:GetID() == 293223 then
+    eq.spawn2(29324,0,0,e.other:GetX() - 10, e.other:GetY(), e.other:GetZ(), e.other:GetHeading())
+    eq.spawn2(29325,0,0,e.other:GetX() + 10, e.other:GetY(), e.other:GetZ(), e.other:GetHeading())
+  end
+end

--- a/kodtaz/293222.lua
+++ b/kodtaz/293222.lua
@@ -1,0 +1,6 @@
+function event_death_complete(e)
+  eq.spawn2(293224,0,0,e.self:GetX() - 10, e.self:GetY(), e.self:GetZ(), 0)
+  eq.spawn2(293224,0,0,e.self:GetX(), e.self:GetY(), e.self:GetZ(), 0)
+  eq.spawn2(293225,0,0,e.self:GetX() + 10, e.self:GetY(), e.self:GetZ(), 0)
+end
+

--- a/kodtaz/293223.lua
+++ b/kodtaz/293223.lua
@@ -1,0 +1,6 @@
+function event_death_complete(e)
+  eq.spawn2(293224,0,0,e.self:GetX() - 10, e.self:GetY(), e.self:GetZ(), e.self:GetHeading())
+  eq.spawn2(293224,0,0,e.self:GetX(), e.self:GetY(), e.self:GetZ(), e.self:GetHeading())
+  eq.spawn2(293225,0,0,e.self:GetX() + 10, e.self:GetY(), e.self:GetZ(), e.self:GetHeading())
+end
+

--- a/kodtaz/Ageless_Relic_Protector.lua
+++ b/kodtaz/Ageless_Relic_Protector.lua
@@ -1,0 +1,4 @@
+function event_death_complete(e)
+  eq.spawn2(29322,0,0,e.other:GetX() - 10, e.other:GetY(), e.other:GetZ(), e.other:GetHeading())
+  eq.spawn2(29323,0,0,e.other:GetX() + 10, e.other:GetY(), e.other:GetZ(), e.other:GetHeading())
+end

--- a/kodtaz/Ageless_Relic_Protector.lua
+++ b/kodtaz/Ageless_Relic_Protector.lua
@@ -1,4 +1,4 @@
 function event_death_complete(e)
-  eq.spawn2(29322,0,0,e.other:GetX() - 10, e.other:GetY(), e.other:GetZ(), e.other:GetHeading())
-  eq.spawn2(29323,0,0,e.other:GetX() + 10, e.other:GetY(), e.other:GetZ(), e.other:GetHeading())
+  eq.spawn2(293222,0,0,e.self:GetX() - 10, e.self:GetY(), e.self:GetZ(), e.self:GetHeading())
+  eq.spawn2(293223,0,0,e.self:GetX() + 10, e.self:GetY(), e.self:GetZ(), e.self:GetHeading())
 end

--- a/kodtaz/Gazak_Klelkek.lua
+++ b/kodtaz/Gazak_Klelkek.lua
@@ -30,7 +30,7 @@ function event_say(e)
   local qglobals = eq.get_qglobals(e.other);
 
   local is_gm = (e.other:Admin() > 80 and e.other:GetGM())
-  local kt_flag = tostring(e.other:GetAccountBucket("god.flags.ket")) or 0
+  local kt_flag = tonumber(e.other:GetAccountBucket("god.flags.kt")) or 0
   local has_kevren_flag = (kt_flag >= 2)
   local finished_first_trial = (kt_flag >= 4)
 
@@ -83,7 +83,7 @@ end
 
 function event_trade(e)
   -- load the current qglobals
-  local kt_flag = tostring(e.other:GetAccountBucket("god.flags.ket")) or 0
+  local kt_flag = tonumber(e.other:GetAccountBucket("god.flags.kt")) or 0
   local has_kevren_flag = (kt_flag >= 2)
   local finished_first_trial = (kt_flag >= 4)
   local item_lib = require("items");

--- a/kodtaz/Gazak_Klelkek.lua
+++ b/kodtaz/Gazak_Klelkek.lua
@@ -30,10 +30,9 @@ function event_say(e)
   local qglobals = eq.get_qglobals(e.other);
 
   local is_gm = (e.other:Admin() > 80 and e.other:GetGM())
-  local has_kevren_flag = (is_gm or (tonumber(qglobals.ikky) and tonumber(qglobals.ikky) >= 1))
-  local finished_first_trial = (tonumber(qglobals.ikky) and tonumber(qglobals.ikky) >= 2)
-
-  local preflag_key = string.format("%s-ikkinz_group1_gazak", e.other:CharacterID())
+  local kt_flag = tostring(e.other:GetAccountBucket("god.flags.ket")) or 0
+  local has_kevren_flag = (kt_flag >= 2)
+  local finished_first_trial = (kt_flag >= 4)
 
   if(e.message:findi("hail")) then
     if not has_kevren_flag then
@@ -60,12 +59,15 @@ function event_say(e)
       e.other:Message(MT.NPCQuestSay, "Gazak Klelkek says, 'You're not ready to eradicate any kind of beast. You still need to speak to Kevren Nalavat about the trials if you're interested in such a thing.'")
     else
       e.other:Message(MT.NPCQuestSay, "Gazak Klelkek says, 'Your task is to battle through the temple and enter an entrance to the inner chambers of the Temple of Singular Might. Once inside you must find the Diabolic Destroyer and kill it before it becomes more powerful. You must recover an artifact from the beast and return it to me. Once you have done this, you will be allowed to move onto the next trial. When you are [" .. eq.say_link("ready to proceed") .. "] and have a group with you, return to me and I shall set you on your way.'")
-      eq.set_data(preflag_key, "1")
+      if kt_flag == 2 then
+        e.other:SetAccountBucket("god.flags.kt", "3")
+	kt_flag = 3
+      end
     end
   elseif (e.message:findi("ready(.*)proceed")) then
     if not is_gm and not has_kevren_flag then
       e.other:Message(MT.NPCQuestSay, "Gazak Klelkek says, 'I really don't believe you're ready to proceed with anything here. You have to speak with Kevren Nalavat to the north about the trials. Return to me when you have spoken with him.'")
-    elseif not is_gm and eq.get_data(preflag_key) == "" then
+    elseif not is_gm and kt_flag == 2 then
       e.other:Message(MT.NPCQuestSay, "Gazak Klelkek says, 'Ready to proceed with what? I know I haven't spoken to you about the [" .. eq.say_link("Diabolic Destroyer") .. "], so that can't be it.'")
     elseif not is_gm and e.other:DoesAnyPartyMemberHaveLockout(expedition_name, "Replay Timer", 6) then
       e.other:Message(MT.NPCQuestSay, "Gazak Klelkek says, 'I'm afraid I cannot allow you to begin, someone in your party has been on this expedition too recently and cannot yet go again.'")
@@ -81,15 +83,16 @@ end
 
 function event_trade(e)
   -- load the current qglobals
-  local qglobals = eq.get_qglobals(e.other);
-  local has_kevren_flag = (tonumber(qglobals.ikky) and tonumber(qglobals.ikky) >= 1)
-  local finished_first_trial = (tonumber(qglobals.ikky) and tonumber(qglobals.ikky) >= 2)
+  local kt_flag = tostring(e.other:GetAccountBucket("god.flags.ket")) or 0
+  local has_kevren_flag = (kt_flag >= 2)
+  local finished_first_trial = (kt_flag >= 4)
   local item_lib = require("items");
+
   if(item_lib.check_turn_in(e.trade, {item1 = 60152})) then
     if has_kevren_flag then
       e.other:Message(MT.NPCQuestSay, ("Gazak Klelkek says, 'Though you were pitted against a most heinous aggressor, you have proven that you are a capable adventurer thus far. Nicely done, %s. I urge you to continue honing your skills. Now that you are ready to move onto the next trial, you should return to Kevren for more information. Good luck!'"):format(e.other:GetCleanName()))
       if not finished_first_trial then
-        eq.set_global("ikky", "2", 5, "F")
+	e.other:SetAccountBucket("god.flags.kt", "4")
         e.other:AddEXP(1)
       end
     else

--- a/kodtaz/Kenra_Kalekkio.lua
+++ b/kodtaz/Kenra_Kalekkio.lua
@@ -22,12 +22,11 @@ function event_say(e)
   local qglobals = eq.get_qglobals(e.other)
 
   local is_gm = (e.other:Admin() > 80 and e.other:GetGM())
-  local has_kevren_flag = (is_gm or (tonumber(qglobals.ikky) and tonumber(qglobals.ikky) >= 1))
-  local finished_first_trial = (is_gm or (tonumber(qglobals.ikky) and tonumber(qglobals.ikky) >= 2))
-  local finished_second_trial = (is_gm or (tonumber(qglobals.ikky) and tonumber(qglobals.ikky) >= 3))
-  local finished_third_trial = (tonumber(qglobals.ikky) and tonumber(qglobals.ikky) >= 4)
-
-  local preflag_key = string.format("%s-ikkinz_group3_kenra", e.other:CharacterID())
+  local kt_flag = tonumber(e.other:GetAccountBucket("god.flags.kt")) or 0
+  local has_kevren_flag = (kt_flag >= 2)
+  local finished_first_trial = (kt_flag >= 4)
+  local finished_second_trial = (kt_flag >= 7)
+  local finished_third_trial = (kt_flag >= 10)
 
   if e.message:findi("hail") then
     if not has_kevren_flag then
@@ -80,7 +79,10 @@ function event_say(e)
       e.other:Message(MT.NPCQuestSay, "Kenra Kalekkio says, 'You can't recover any relics from this temple yet. You have to complete the second trial first! Go find Maroley Nazuey at the Temple of Twin Struggles for more information on the second trial.'")
     else
       e.other:Message(MT.NPCQuestSay, "Kenra Kalekkio says, 'This is your final trial and will prove, once and for all, if you are capable of taking on the more serious issues concerning the Muramites. You must fight through the temple and enter an entrance to the inner chambers of the Temple of the Tri-Fates. Once inside, kill the Tri-Fates and return the relics. When you are [" .. eq.say_link("ready to begin") .. "] and have a group with you, return to me, and I shall send you on your way.'")
-      eq.set_data(preflag_key, "1")
+      if kt_flag == 8 then
+        e.other:SetAccountBucket("god.flags.kt", "9")
+	kt_flag = 9
+      end
     end
   elseif e.message:findi("ready(.*)begin") then
     if not has_kevren_flag then
@@ -89,7 +91,7 @@ function event_say(e)
       e.other:Message(MT.NPCQuestSay, "Kenra Kalekkio says, 'I don't think you're ready to begin anything except for the first trial. That's all you can do for the time being, but you need to find Gazak Klelkek at the Temple of Singular Might so he can guide you through it.'")
     elseif not finished_second_trial then
       e.other:Message(MT.NPCQuestSay, "Kenra Kalekkio says, 'What is it that you believe you're ready to begin? I hope you don't believe it has anything to do with me yet. You still need to finish the second trial and, to do so, you need to find Maroley Nazuey at the Temple of Twin Struggles and have her give you that information.'")
-    elseif not is_gm and eq.get_data(preflag_key) == "" then
+    elseif not is_gm and kt_flag == 8 then
       e.other:Message(MT.NPCQuestSay, "Kenra Kalekkio says, 'You say you think you're ready to begin something? Does that have anything to do with your [" .. eq.say_link("final test") .. "]?'")
     elseif not is_gm and e.other:DoesAnyPartyMemberHaveLockout(expedition_name, "Replay Timer", 6) then
       e.other:Message(MT.NPCQuestSay, "Kenra Kalekkio says, 'I'm afraid I cannot allow you to begin, someone in your party has been on this expedition too recently and cannot yet go again.'")
@@ -104,12 +106,11 @@ function event_say(e)
 end
 
 function event_trade(e)
-  local qglobals = eq.get_qglobals(e.other)
-
-  local has_kevren_flag = (tonumber(qglobals.ikky) and tonumber(qglobals.ikky) >= 1)
-  local finished_first_trial = (tonumber(qglobals.ikky) and tonumber(qglobals.ikky) >= 2)
-  local finished_second_trial = (tonumber(qglobals.ikky) and tonumber(qglobals.ikky) >= 3)
-  local finished_third_trial = (tonumber(qglobals.ikky) and tonumber(qglobals.ikky) >= 4)
+  local kt_flag = tonumber(e.other:GetAccountBucket("god.flags.kt")) or 0
+  local has_kevren_flag = (kt_flag >= 2)
+  local finished_first_trial = (kt_flag >= 4)
+  local finished_second_trial = (kt_flag >= 7)
+  local finished_third_trial = (kt_flag >= 10)
 
   local item_lib = require("items")
 
@@ -126,7 +127,7 @@ function event_trade(e)
     else
       e.other:Message(MT.NPCQuestSay, ("Kenra Kalekkio says, 'I am astounded that you have completed the trial so easily! You have gone above and beyond our expectations and are ready to continue beyond mere trials! Congratulations, %s! At this time, you should return to Kevren so he can guide you on your way from here on out.'"):format(e.other:GetCleanName()))
       if not finished_third_trial then
-        eq.set_global("ikky", "4", 5, "F");
+        e.other:SetAccountBucket("god.flags.kt", "10")
         e.other:AddEXP(1)
       end
     end

--- a/kodtaz/Kevren_Nalavat.lua
+++ b/kodtaz/Kevren_Nalavat.lua
@@ -1,21 +1,21 @@
 function event_say(e)
   local kt_flag = tonumber(e.other:GetAccountBucket("god.flags.kt")) or 0
 
-  --Flag 0: I don't know how but you're in Kod'taz?  Kevran should send you to the right place.
+  --Flag 0: I don't know how but you're in Kod'taz?  Kevren should send you to the right place.
   if kt_flag == 0 then
     if e.message:findi("hail") then
-      e.other:Message(MT.NPCQuestSay, "Kevran Nalavat says, 'Hello, are you assisting the Wayfarers Brotherhood?  If so, I have heard there are troubles still in the city below us.  You should return there and seek out High Priest Riwirn in the section of the city called Barindu and speak with him.'")
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says, 'Hello, are you assisting the Wayfarers Brotherhood?  If so, I have heard there are troubles still in the city below us.  You should return there and seek out High Priest Riwirn in the section of the city called Barindu and speak with him.'")
     end
   end
 
-  -- If you don't have Flag 19 or higher, Kevran has nothing for you if you ask about BiC.
+  -- If you don't have Flag 19 or higher, Kevren has nothing for you if you ask about BiC.
   if kt_flag < 19 then
     if e.message:findi("have done all you asked") then
-      e.other:Message(MT.NPCQuestSay, "Kevrean Nalavat shakes his head, 'I believe we still have more work to do before I can trust you with the information I have for L`diava.'")
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat shakes his head, 'I believe we still have more work to do before I can trust you with the information I have for L`diava.'")
     end
   end
 
-  -- Flag 19: You're done with Kevran
+  -- Flag 19: You're done with Kevren
   if kt_flag >= 19 then
     if e.message:findi("hail") then
        e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Welcome back, " .. e.other:GetCleanName() ..".  You have done all I have asked, but you should see if Tublik needs you for anything else.  Otherwise, if you'd like, we have a chance now to talk [" .. eq.say_link("more") .. "]. You're also more than welcome to attempt the trials again. If so, just let me know you're [" .. eq.say_link("ready to test") .. "] again and we'll proceed down that path. What'll it be, " .. e.other:GetCleanName() .. "?'")
@@ -122,7 +122,7 @@ function event_say(e)
   --Flag 8 and 9: You should be doing the trial
   if kt_flag == 8 or kt_flag == 9 then
     if e.message:findi("hail") then
-      e.other:Message(MT.NPCQuestSay, "Kevran Nalavat says, 'Good luck with the third trial, " .. e.other:GetCleanName() .. "!  Be sure to return the artifact you obtain from the trial to Kenra Kalekkio.")
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says, 'Good luck with the third trial, " .. e.other:GetCleanName() .. "!  Be sure to return the artifact you obtain from the trial to Kenra Kalekkio.")
     end
   end
 
@@ -143,7 +143,7 @@ function event_say(e)
   --Flag 5 and 6: You should be doing the trial
   if kt_flag == 5 or kt_flag == 6 then
     if e.message:findi("hail") then
-      e.other:Message(MT.NPCQuestSay, "Kevran Nalavat says, 'Good luck with the second trial, " .. e.other:GetCleanName() .. "!  Be sure to return the artifact you obtain from the trial to Maroley Nazuey.")
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says, 'Good luck with the second trial, " .. e.other:GetCleanName() .. "!  Be sure to return the artifact you obtain from the trial to Maroley Nazuey.")
     end
   end
 
@@ -167,7 +167,7 @@ function event_say(e)
   --Flag 2 and 3: You should be doing the trial
   if kt_flag == 2 or kt_flag == 3 then
     if e.message:findi("hail") then
-      e.other:Message(MT.NPCQuestSay, "Kevran Nalavat says, 'Good luck with the first trial, " .. e.other:GetCleanName() .. "!  Be sure to return the artifact you obtain from the trial to Gazak Klelkek.")
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says, 'Good luck with the first trial, " .. e.other:GetCleanName() .. "!  Be sure to return the artifact you obtain from the trial to Gazak Klelkek.")
     end
   end
 
@@ -212,22 +212,22 @@ function event_say(e)
         e.other:Message(MT.Yellow, "Finished! - You can now retry any of the trials at any time!")
       end
       if kt_flag == 2 or kt_flag == 3 then
-        e.other:Message(MT.Yellow, "Pending - You have been commissioned by Kevran Nalavat to undertake the Trial of Singular Might.")
+        e.other:Message(MT.Yellow, "Pending - You have been commissioned by Kevren Nalavat to undertake the Trial of Singular Might.")
       elseif kt_flag >= 4 then
         e.other:Message(MT.Yellow, "Finished! - You have completed the trial at the Temple of Singular Might!")
       end
       if kt_flag == 5 or kt_flag == 6 then
-        e.other:Message(MT.Yellow, "Pending - You have been commissioned by Kevran Nalavat to undertake the Trial of Twin Struggles.")
+        e.other:Message(MT.Yellow, "Pending - You have been commissioned by Kevren Nalavat to undertake the Trial of Twin Struggles.")
       elseif kt_flag >= 7 then
         e.other:Message(MT.Yellow, "Finished! - You have completed the trial at the Temple of Twin Struggles!")
       end
       if kt_flag == 8 or kt_flag == 9 then
-        e.other:Message(MT.Yellow, "Pending - You have been commissioned by Kevran Nalavat to undertake the Trial of Tri-Fates")
+        e.other:Message(MT.Yellow, "Pending - You have been commissioned by Kevren Nalavat to undertake the Trial of Tri-Fates")
       elseif kt_flag >= 10 then
         e.other:Message(MT.Yellow, "Finished! - You have completed the trial at the Temple of Tri-Fates!")
       end
       if kt_flag == 11 then
-        e.other:Message(MT.Yellow, "Pending - You have been commissioned by Kevran Nalavat to investigate the Martyrs Passage.")
+        e.other:Message(MT.Yellow, "Pending - You have been commissioned by Kevren Nalavat to investigate the Martyrs Passage.")
       end
       if kt_flag >= 12 then
         e.other:Message(MT.Yellow, "Finished! - You returned four relics from the Martyrs Passage!")

--- a/kodtaz/Kevren_Nalavat.lua
+++ b/kodtaz/Kevren_Nalavat.lua
@@ -1,0 +1,389 @@
+function event_say(e)
+  local kt_flag = tonumber(e.other:GetAccountBucket("god.flags.kt")) or 0
+
+  --Flag 0: I don't know how but you're in Kod'taz?  Kevran should send you to the right place.
+  if kt_flag == 0 then
+    if e.message:findi("hail") then
+      e.other:Message(MT.NPCQuestSay, "Kevran Nalavat says, 'Hello, are you assisting the Wayfarers Brotherhood?  If so, I have heard there are troubles still in the city below us.  You should return there and seek out High Priest Riwirn in the section of the city called Barindu and speak with him.'")
+    end
+  end
+
+  -- If you don't have Flag 19 or higher, Kevran has nothing for you if you ask about BiC.
+  if kt_flag < 19 then
+    if e.message:findi("have done all you asked") then
+      e.other:Message(MT.NPCQuestSay, "Kevrean Nalavat shakes his head, 'I believe we still have more work to do before I can trust you with the information I have for L`diava.'")
+    end
+  end
+
+  -- Flag 19: You're done with Kevran
+  if kt_flag >= 19 then
+    if e.message:findi("hail") then
+       e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Welcome back, " .. e.other:GetCleanName() ..".  You have done all I have asked, but you should see if Tublik needs you for anything else.  Otherwise, if you'd like, we have a chance now to talk [" .. eq.say_link("more") .. "]. You're also more than welcome to attempt the trials again. If so, just let me know you're [" .. eq.say_link("ready to test") .. "] again and we'll proceed down that path. What'll it be, " .. e.other:GetCleanName() .. "?'")
+    end
+    --TODO: Add BiC here
+  end
+
+  -- Flag 18: You should turn in the Grand Summonter's Glyphs
+  if kt_flag == 18 then
+    if e.message:findi("hail") then
+       e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Welcome back, " .. e.other:GetCleanName() ..". Were you able to stop the muramite summoners?  If so, please hand the glyph you found to me.  Otherwise, if you'd like, we have a chance now to talk [" .. eq.say_link("more") .. "]. You're also more than welcome to attempt the trials again. If so, just let me know you're [" .. eq.say_link("ready to test") .. "] again and we'll proceed down that path. What'll it be, " .. e.other:GetCleanName() .. "?'")
+    end
+  end
+
+  -- Flag 17: Summoner's Ring
+  if kt_flag == 17 then
+    if e.message:findi("hail") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Welcome back, " .. e.other:GetCleanName() .. ". I've studied the glyph as much as I can for now. In addition to what we uncovered with the translated glyph, we've received word that the [" .. eq.say_link("rumors") .. "] of a dark summoning are indeed true. The truth of these rumors is no surprise to me at all with all that we've uncovered thus far. The Legion of Mata Muram is evil indeed I have a moment if you want to talk a bit [" .. eq.say_link("more") .. "] about me. You're also more than welcome to attempt the trials again. If so, just let me know you're [" .. eq.say_link("ready to test") "] again and we'll proceed down that path. What'll it be, " .. e.other:GetCleanName() .. "?")
+    end
+    if e.message:findi("rumors") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'It looks as though the invaders are planning on bringing beasts into this world by means of a collective summoning. We're unsure if they're even able to do this, but we do know that they cannot be allowed the chance to succeed. You are charged with finding the Muramites attempting this summoning and putting a stop to them at once! Is this something you [" .. eq.say_link("think you can do") .. "]?'")
+    end
+    if e.message:findi("can do") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'I hoped as much. What I ask of you now won't be easy. You must gather a raiding force several times the size of your normal party. We fear that only sufficient force will be enough to stop this threat. Once you have your party in tow, make your way to the summoning circle, and vanquish the threat of the evil legion priests before they bring their minions into this realm. I have one [" .. eq.say_link("final warning") .. "] for you before you go.'")
+    end
+    if e.message:findi("final warning") then
+      e.other:Message(MT.NPCQuestSya, "Kevren Nalavat says 'I am unsure of the Muramites' timing. It is possible that I have heard incorrectly and that the summoning force may not be there at this time. Do not take this to mean that I was wrong! The force will be there, but it may take them a few more hours to assemble. Be patient. They will arrive. Lastly, the rumors have stated that these legion priests will be using some special artifacts they have collected. We do not know what these artifacts are, but you must return one of these artifacts to me when you have finished so that we can examine it. Good luck, " .. e.other:GetCleanName() .. ", I fear you may need it.'")
+      e.other:SetAccountBucket("god.flags.kt", "18")
+    end
+  end
+
+  --Flag 16: You should turn in the Translated Glyph of the Damned
+  if kt_flag == 16 then
+    if e.message:findi("hail") then
+       e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Welcome back, " .. e.other:GetCleanName() ..". Were you able to translate the glyphs?  If so, please hand the result to me.  Otherwise, if you'd like, we have a chance now to talk [" .. eq.say_link("more") .. "]. You're also more than welcome to attempt the trials again. If so, just let me know you're [" .. eq.say_link("ready to test") .. "] again and we'll proceed down that path. What'll it be, " .. e.other:GetCleanName() .. "?'")
+    end
+  end
+
+  --Flag 15: Stone Tablet
+  if kt_flag == 15 then
+    if e.message:findi("hail") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Welcome back, " .. e.other:GetCleanName() ..". You should find Tublik Narwether and ask him for a stone tablet.  Otherwise, if you'd like, we have a chance now to talk [" .. eq.say_link("more") .. "]. You're also more than welcome to attempt the trials again. If so, just let me know you're [" .. eq.say_link("ready to test") .. "] again and we'll proceed down that path. What'll it be, " .. e.other:GetCleanName() .. "?'")
+    end
+  end
+
+  --Flag 14: You should turn in the glyphs
+  if kt_flag == 14 then
+    if e.message:findi("hail") then
+       e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Welcome back, " .. e.other:GetCleanName() ..". Did you find the relics in the Temple of the Damned?  If so, please hand them to me.  Otherwise, if you'd like, we have a chance now to talk [" .. eq.say_link("more") .. "]. You're also more than welcome to attempt the trials again. If so, just let me know you're [" .. eq.say_link("ready to test") .. "] again and we'll proceed down that path. What'll it be, " .. e.other:GetCleanName() .. "?'")
+    end
+  end
+
+  --Flag 13: Temple of the Damned
+  if kt_flag == 13 then
+    if e.message:findi("hail") then
+       e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Hello again, " .. e.other:GetCleanName() .. ". I've been studying the information you retrieved from the Martyrs Passage and I do believe we have a [" .. eq.say_link("problem") .. "] on our hands. I have a moment if you want to talk a bit [" .. eq.say_link("more") .. "] about me. You're also more than welcome to attempt the trials again. If so, just let me know you're [" .. eq.say_link("ready to test") "] again and we'll proceed down that path. What'll it be, " .. e.other:GetCleanName() .. "?")
+    end
+    if e.message:findi("problem") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'The problem is that this information reveals a most disturbing plot by the Muramites to summon a creature into this realm. They appear to be experts in teleportation. The parchment you returned to me described the use of the Temple of the Damned to gather instruments of power that will allow the beast to coalesce in our world. It doesn't go into what those instruments are or when the summoning will take place, so you must [" .. eq.say_link("discover their plans") .. "].'")
+    end
+    if e.message:findi("discover their plans") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'You must go into the Temple of the Damned. It is the temple directly behind me with the fog looming around it. Explore the temple and search for the instruments of power that the Legion of Mata Muram priests are collecting. Once you have the relics in hand, return them to me so I can study them further. Good luck to you, " .. e.other:GetCleanName() .. ".'")
+      e.other:SetAccountBucket("god.flags.kt", "14")
+    end
+  end
+
+  --Flag 12: You should turn in the skin
+  if kt_flag == 12 then
+    if e.message:findi("hail") then
+       e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Welcome back, " .. e.other:GetCleanName() ..". Did you find something else from the muramites in Martyr's Passage?  If so, please hand it to me.  Otherwise, if you'd like, we have a chance now to talk [" .. eq.say_link("more") .. "]. You're also more than welcome to attempt the trials again. If so, just let me know you're [" .. eq.say_link("ready to test") .. "] again and we'll proceed down that path. What'll it be, " .. e.other:GetCleanName() .. "?'")
+    end
+  end
+
+  --Flag 11: You should turn in the relics
+  if kt_flag == 11 then
+    if e.message:findi("hail") then
+       e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Welcome back, " .. e.other:GetCleanName() ..". Were you able to find the relics in Martyr's Passage?  If so, please hand them to me.  Otherwise, if you'd like, we have a chance now to talk [" .. eq.say_link("more") .. "]. You're also more than welcome to attempt the trials again. If so, just let me know you're [" .. eq.say_link("ready to test") .. "] again and we'll proceed down that path. What'll it be, " .. e.other:GetCleanName() .. "?'")
+    end
+  end
+
+  --Flag 10: Trials complete, moving on
+  if kt_flag == 10 then
+    if e.message:findi("hail") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Welcome back, " .. e.other:GetCleanName() ..". I must congratulate you on your recent completion of all three trials. I must admit that I was unsure of your ability to do as well as you did. Now that you have finished, you have the choice of taking on some [" .. eq.say_link("other tasks") .. "]. If you'd like, we have a chance now to talk [" .. eq.say_link("more") .. "]. You're also more than welcome to attempt the trials again. If so, just let me know you're [" .. eq.say_link("ready to test") .. "] again and we'll proceed down that path. What'll it be, " .. e.other:GetCleanName() .. "?'")
+    end
+    if e.message:findi("other tasks") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'As I suspected, you're ready for some challenging work! I must warn you though, what lies ahead is not for the faint of heart.  The task I need now is someone to investigate the[" .. eq.say_link("Martyrs Passage") .. "].")
+    end
+    if e.message:findi("martyrs passage") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Good, we're in need of a sturdy adventurer to help us with a dire situation along the Martyrs Passage. First, this area was named so because it houses the spirits of martyred heroes lost long ago. The trusik lined the passageway with [" .. eq.say_link("ancient relics") "] to sooth the spirits while in the afterlife. Unfortunately, the Muramites are disturbing the remains and are looking to collect the spiritual remnants for some sinister use.'")
+    end
+    if e.message:findi("ancient relics") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'We're unsure what the invaders are gathering these particular relics for. From what I can surmise, none of them have any kind of magical properties. In any case, it's up to you and a group of adventurers to venture to the Martyrs Passage and [" .. eq.say_link("investigate") .. "] the situation. I've heard reports of ghosts in that area, so the invaders may have stirred up something unexpected.'")
+    end
+    if e.message:findi("investigate") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'You'll need to head to the Martyrs Passage and recover four different relics. I advise taking a sturdy group with you because there may be invaders there in the process of burgling the passage. If you uncover any information on what the Mata Muram are planning to use these relics for, return that to me as well. Do you [" .. eq.say_link("understand") .. "] your objective?'")
+    end
+    if e.message:findi("understand") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Good, be on your way then. Return to me when you have completed your objective. I wish you luck and await your return.'")
+      e.other:SetAccountBucket("god.flags.kt", "11")
+    end
+  end
+
+  --Flag 8 and 9: You should be doing the trial
+  if kt_flag == 8 or kt_flag == 9 then
+    if e.message:findi("hail") then
+      e.other:Message(MT.NPCQuestSay, "Kevran Nalavat says, 'Good luck with the third trial, " .. e.other:GetCleanName() .. "!  Be sure to return the artifact you obtain from the trial to Maroley Nazuey.")
+    end
+  end
+
+  --Flag 7: Trial of Tri-Fates
+  if kt_flag == 7 then
+    if e.message:findi("hail") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Welcome back, " .. e.other:GetCleanName() .. ". Reports of your actions in the Temple of Twin Struggles suggest that you may be well on your way to becoming an outstanding addition to the coalition that investigates these temples. I continue standing my post and, boring as it is, it is of no interest to you I'm sure. If you want, we can talk [" .. eq.say_link("more") .. "] when we have some idle time. For now, if you're [" .. eq.say_link("ready to continue testing") .. "], we can proceed! What'll it be, " .. e.other:GetCleanName() .. "?'")
+    end
+    if e.message:findi("singular might") or e.message:findi("twin struggles") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat shakes his head, 'You have already completed that trial, the brotherhood needs you to move on to the next challenges before you can return to a trial.")
+    end
+    if e.message:findi("tri-fates") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Beyond the dark fog to the south lies the Temple of the Tri-Fates. It is the northern-most temple of the three. In front of the temple you will encounter three smaller temples and it is there you will find another of the brotherhood waiting for you. Seek out and speak with Kenra Kalekkio about the troubles within the temple.'")
+      e.other:SetAccountBucket("god.flags.kt", "8")
+    end
+  end 
+
+  --Flag 5 and 6: You should be doing the trial
+  if kt_flag == 5 or kt_flag == 6 then
+    if e.message:findi("hail") then
+      e.other:Message(MT.NPCQuestSay, "Kevran Nalavat says, 'Good luck with the second trial, " .. e.other:GetCleanName() .. "!  Be sure to return the artifact you obtain from the trial to Maroley Nazuey.")
+    end
+  end
+
+  --Flag 4: Trial of Twin Struggles
+  if kt_flag == 4 then
+    if e.message:findi("hail") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Welcome back, " .. e.other:GetCleanName() .. ". Reports of your actions in the Temple of Singular Might suggest that you may be well on your way to becoming an outstanding addition to the coalition that investigates these temples. I continue standing my post and, boring as it is, it is of no interest to you I'm sure. If you want, we can talk [" .. eq.say_link("more") .. "] when we have some idle time. For now, if you're [" .. eq.say_link("ready to continue testing") .. "], we can proceed! What'll it be, " .. e.other:GetCleanName() .. "?'")
+    end
+    if e.message:findi("twin struggles") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Beyond the dark fog to the south lies the Temple of Twin Struggles. It is the southern-most temple of the three. In front of the temple you will encounter two smaller temples and it is there you will find another of the brotherhood waiting for you. Seek out and speak with Maroley Nazuey about the troubles within the temple.'")
+      e.other:SetAccountBucket("god.flags.kt", "5")
+    end
+    if e.message:findi("singular might") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat shakes his head, 'You have already completed that trial, the brotherhood needs you to move on to the next challenges before you can return to a trial.")
+    end
+    if e.message:findi("tri-fates") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'I'm sorry " .. e.other:GetCleanName() .. ", but you're not ready to face the third trial. You must first find Maroley Nazuey near the Temple of [" .. eq.say_link("Twin Struggles") .. "] and finish the second trial before you may proceed. Return to me when you have accomplished that feat.'")
+    end
+  end
+
+  --Flag 2 and 3: You should be doing the trial
+  if kt_flag == 2 or kt_flag == 3 then
+    if e.message:findi("hail") then
+      e.other:Message(MT.NPCQuestSay, "Kevran Nalavat says, 'Good luck with the first trial, " .. e.other:GetCleanName() .. "!  Be sure to return the artifact you obtain from the trial to Gazak Klelkek.")
+    end
+  end
+
+  --Flag 1: Trial of Singular Might
+  if kt_flag == 1 then
+    if e.message:findi("hail") then
+      e.other:Message(MT.NPCQuestSay, "Kevren looks relieved to see you. 'Finally the Wayfarers Brotherhood has sent adventurers this far out. I was beginning to wonder what was happening. I'm Kevren Nalavat, one of the brotherhood's traveling scholars. We can talk [" .. eq.say_link("more") .. "] later. The important thing is that you're here and now that you are you'll need to prove that you're up to the challenges facing us on this rugged terrain. I've been all through this area and it's no place to be caught unaware! So what do you say?  Are you [" .. eq.say_link("ready to be tested") .. "]?'")
+    end
+    if e.message:findi("singular might") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Beyond the dark fog to the south lies the Temple of Singular Might. You can find it between the two other temples. In front of the temple you will find a single, smaller temple where another of the brotherhood is waiting for you. Seek out Gazak Klelkek and speak to him about the troubles within the temple.'")
+      e.other:SetAccountBucket("god.flags.kt", "2")
+    end
+    if e.message:findi("twin struggles") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'I'm sorry " .. e.other:GetCleanName() .. ", but you're not ready to face the second trial. You must first find Gazak Klelkek near the Temple of [" .. eq.say_link("Singular Might") .. "] and finish the first trial before you may proceed. Return to me when you have accomplished that feat.'")
+    end
+    if e.message:findi("tri-fates") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'I'm sorry " .. e.other:GetCleanName() .. ", but you're not ready to face the third trial. You must first find Gazak Klelkek near the Temple of [" .. eq.say_link("Singular Might") .. "] and finish the first trial before you may proceed. Return to me when you have accomplished that feat.'")
+    end
+  end
+
+  --Flags 10 and up: Redo trials
+  if kt_flag >= 11 then
+    if e.message:findi("ready to test") then
+      e.other:Message(MT.NPCQuestSay, "Kevren nods his approval, 'Good to hear! If you're interested or have forgotten I can give you some [" .. eq.say_link("background information") .. "] about the mountaintop. If you're ready to proceed, I can explain the [" .. eq.say_link("trials") .. "] to you once more.'")
+    end
+  end
+
+  --Flags 4 through 10: Continue Testing
+  if kt_flag >= 4 and kt_flag < 11 then
+    if e.message:findi("ready to continue testing") then
+      e.other:Message(MT.NPCQuestSay, "Kevren nods his approval, 'Good to hear! If you're interested or have forgotten I can give you some [" .. eq.say_link("background information") .. "] about the mountaintop. If you're ready to proceed, I can explain the [" .. eq.say_link("trials") .. "] to you once more.'")
+    end
+  end
+
+  --Flags 2 and up: Progress Report
+  if kt_flag >= 2 then
+    if e.message:findi("hail") then
+      e.other:Message(MT.Yellow, "Kevren Nalavat says 'If you want to see what you've completed at any time, just ask me for a [" .. eq.say_link("progress update") .. "]!'") 
+    end
+    if e.message:findi("progress update") then
+      if kt_flag >= 11 then
+	e.other:Message(MT.Yellow, "Finished! - You can now retry any of the trials at any time!")
+      end
+      if kt_flag == 2 or kt_flag == 3 then
+        e.other:Message(MT.Yellow, "Pending - You have been commissioned by Kevran Nalavat to undertake the Trial of Singular Might.")
+      elseif kt_flag >= 4 then
+        e.other:Message(MT.Yellow, "Finished! - You have completed the trial at the Temple of Singular Might!")
+      end
+      if kt_flag == 5 or kt_flag == 6 then
+	e.other:Message(MT.Yellow, "Pending - You have been commissioned by Kevran Nalavat to undertake the Trial of Twin Struggles.")
+      elseif kt_flag >= 7 then
+        e.other:Message(MT.Yellow, "Finished! - You have completed the trial at the Temple of Twin Struggles!")
+      end
+      if kt_flag == 8 or kt_flag == 9 then
+        e.other:Message(MT.Yellow, "Pending - You have been commissioned by Kevran Nalavat to undertake the Trial of Tri-Fates")
+      elseif kt_flag >= 10 then
+	e.other:Message(MT.Yellow, "Finished! - You have completed the trial at the Temple of Tri-Fates!")
+      end
+      if kt_flag == 11 then
+        e.other:Message(MT.Yellow, "Pending - You have been commissioned by Kevran Nalavat to investigate the Martyrs Passage.")
+      end
+      if kt_flag >= 12 then
+	e.other:Message(MT.Yellow, "Finished! - You returned four relics from the Martyrs Passage!")
+      end
+      if kt_flag == 12 then
+	e.other:Message(MT.Yellow, "Pending - You haven't yet returned any information as to why the Muramites are in Martyrs Passage.")
+      end
+      if kt_flag >= 13 then
+	e.other:Message(MT.Yellow, "Finished! - You returned valuable information as to why the Muramites are in the Martyrs Passage!")
+      end
+      if kt_flag >= 14 then
+	e.other:Message(MT.Yellow, "Finished! - You've been comissioned to investigate the Temple of the Damned.")
+      end
+      if kt_flag >= 15 then
+	e.other:Message(MT.Yellow, "Finished! - You've recovered important glyphs from the Temple of the Damned!")
+      end
+      if kt_flag == 15 or kt_flag == 16 then
+        e.other:Message(MT.Yellow, "Pending - You haven't translated the glyphs gathered from the Temple of the Damned.")
+      end
+      if kt_flag >= 17 then
+	e.other:Message(MT.Yellow, "Finished! - You've successfully translated the glyphs you found in the Temple of the Damned!")
+      end
+      if kt_flag >= 18 then
+	e.other:Message(MT.Yellow, "Finished! - You've been charged with stopping the ceremony at the Summoning Circle!")
+      end
+      if kt_flag >= 19 then
+	e.other:Message(MT.Yellow, "Finished! - You were able to recover a rare artifact from the Grand Summoner's goons in the Summoning Circle!")
+      end
+      if kt_flag >= 20 then
+	e.other:Message(MT.Yellow, "Finished! - You've been sent to gather any clues you can find from the Crumbled Sanctuary of Divine Destruction!")
+      end
+      if kt_flag >= 21 then
+	e.other:Message(MT.Yellow, "Finished! - You have collected the four Frayed Flesh Scraps from the Crumbled Sanctuary of Divine Destruction!")
+      end
+      if kt_flag >= 22 then
+	e.other:Message(MT.Yellow, "Finished! - You've sewn the flesh scraps together to make the Sewn Flesh Parchment!")
+      end
+      if kt_flag >= 23 then
+	e.other:Message(MT.Yellow, "Finished! - You've found the three clues from the three trial temples!")
+      end
+      if kt_flag >= 24 then
+	e.other:Message(MT.Yellow, "Finished! - You've recovered the Artifact of Righteousness!")
+      end
+      if kt_flag >= 25 then
+	e.other:Message(MT.Yellow, "Finished! - You've recovered the Artifact of Glorification!")
+      end
+      if kt_flag >= 26 then
+	e.other:Message(MT.Yellow, "Finished! - You've recovered the Artifact of Transcendence!")
+      end
+      if kt_flag >= 27 then
+	e.other:Message(MT.Yellow, "Finished! - You've been instructed on what needs to be done to make the Icon of the Altar!")
+      end
+      if kt_flag >= 28 then
+	e.other:Message(MT.Yellow, "Finished! - You've constructed your Icon of the Altar!")
+      end
+      if kt_flag >= 29 then
+        e.other:Message(MT.Yellow, "You have obtained a Sliver of the High Temple!  Congratulations!")
+      end
+      if kt_flag == 30 then
+	e.other:Message(MT.Yellow, "The barrier to Qvic has been breeched by your possession of the Sliver of the High Temple and the Fragment of the High Temple!")
+      end
+      if kt_flag < 30 then
+	e.other:Message(MT.Yellow, "Kod'taz still has secrets to discover...")
+      end
+    end
+  end
+
+  --Flags 1+: Lore
+  if kt_flag >= 1 then
+    if e.message:findi("ready to be tested") then
+      e.other:Message(MT.NPCQuestSay, "Kevren nods his approval, 'Good to hear! If you're interested I can give you a little [" .. eq.say_link("background information") .. "] about the mountaintop here before we get started, otherwise I'll explain the [" .. eq.say_link("trials") .. "] to you.'")
+    end
+    if e.message:findi("more") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Well I haven't always been the bold adventurer you see before you. I know I may not look too daring, but that's because I'm trying to keep a low profile. Before I joined the Wayfarers Brotherhood I was a learned scholar and knowledge-seeker. I sought to uncover the mysteries of ancient ruins and civilizations lost long ago. I was so focused on my studies that most of my colleagues thought I bordered on [" .. eq.say_link("crazy") .. "].'")
+    end
+    if e.message:findi("crazy") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Yes, crazy. I didn't mind though. I knew most of them would never uncover a full understanding of the past like I was. I continued my studies until I was approached by Morden Rasp -- I'm sure you've heard of him. He contacted me and said he was going to begin gathering artifacts from civilizations lost to the ages and that my skills were going to be needed in the times to come. I couldn't help but [" .. eq.say_link("join him") .. "].'")
+    end
+    if e.message:findi("join him") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'His offer was irresistible! Since I joined the brotherhood I have provided my continuing expertise about lost civilizations. Of course, Morden told me that just being a scholar wasn't going to be enough. He said I had to learn some other skill to stay with the brotherhood as an explorer. I had already learned so much so quickly and didn't dare leave with all the new and exciting items we were getting from adventurers, so I decided to learn how to become a rogue so I could [" .. eq.say_link("sneak around") .. "] to collect what I needed.'")
+    end
+    if e.message:findi("sneak around") then
+      e.other:Message(MT.NPCQuestSay, "Kevren looks towards the ground, shamefully. 'It wasn't the most glamorous thing to do, I know. But you have to understand that I have never been the adventurous type! I certainly didn't want glamour of any kind. I figured sneaking around to gather [" .. eq.say_link("what was needed") .. "] would be easier than trying to fight my way through. Plus, sneaking around allowed me to go alone into ruins so I didn't need to rely on anyone.")
+    end
+    if e.message:findi("what was needed") then
+      e.other:Message(MT.NPCQuestSay, "Kevren suddenly looks up at you with renewed earnest. 'Oh you wouldn't believe the things I've already found out about the people who built the temples around here! Well firstly, it's been a bit more difficult than usual to find anything out about them because they have no written history -- they tell stories complemented with glyphs to recount their history. I've learned how to interpret most of the glyphs I've encountered so far and believe me when I say that it's been some of the most interesting work I've done thus far. That reminds me, do you want to hear some more about the [" .. eq.say_link("background information") .. "] of this area or are you ready to learn about the [" .. eq.say_link("trials") .. "]?'")
+    end
+    if e.message:findi("background information") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Good. There's no use going into an area without knowing the lay of the land. The first thing you should know is that you're walking into a huge expanse at the top of the mountain. It must have taken several years to dig out all the rock from the mountain. With the space they dug out they were able to build grand temples into the side of the mountain. Until you've seen them for yourself you can't imagine their [" .. eq.say_link("grandeur") .. "].'")
+    end
+    if e.message:findi("grandeur") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Oh indeed! The trusik -- that's what they call themselves -- had powerful geomancers that must have expended huge amounts of energy to shape and mold the mountain. They used mighty golems to clear away the rubble so they could continue their work. The temples they built are all in recognition to [" .. eq.say_link("some being") .. "] they worshiped long ago and some of them seem to reach the sky!'")
+    end
+    if e.message:findi("some being") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'From what I've been able to gather these people prayed to a god they call Trushar. They believed Trushar was the one who controlled the seas. It was to this deity that they prayed for the destruction of all non-believers and those who exiled them. I tend to wonder if they [" .. eq.say_link("prayed for the destruction") .. "] of non-believers or the nihil in the city.'")
+    end
+    if e.message:findi("prayed for the destruction") then
+      e.other:Message(MT.NPCQuestSay, "Kevren scrunches his brow thoughtfully. 'From the information I've sorted through so far, the nihil in the city kicked the trusik out because they were tired of the fanatic belief in their beloved sea god. I even think that's where the name trusik comes from, a title for exiled believers of a non-existent being. I'm hoping that we can uncover some more of those [" .. eq.say_link("mysteries") .. "] in the temples beyond.'")
+    end
+    if e.message:findi("mysteries") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'There are still some things that are left unexplained. Most importantly is the fact that we don't know how deep the invader presence goes. We need to discover some of the reasons for the temples, what purpose they serve now, and what the invaders have to do with them. We need to investigate the temples and the remains further for this information. That's where [" .. eq.say_link("you come in") .. "].'")
+    end
+    if e.message:findi("come in") then
+      e.other:Message(MT.NPCQuestSay, "Kevren sighs, 'I haven't had a lot of time to look around the temples, because I was commissioned to scout ahead and remain here for the adventuring parties that would be sent shortly after. Now that those parties are being sent, I have to maintain my post and make sure that those we're sending in to look for the information for us are up to the task. That's the very reason we have designed the [" .. eq.say_link("trials") .. "].'")
+    end
+    if e.message:findi("trials") then
+      e.other:Message(MT.NPCQuestSay, "Kevren's look turns serious. 'There are any number of new threats with these invaders and we're unsure just how powerful or how many of them there are. We need to make sure that those of you being sent up here to find that information out for us won't be scared off by the destructive force these invaders bring along with them. The trials must be done in a [" .. eq.say_link("specific order") .. "] and must all be completed before we can allow you to attempt any further work for the brotherhood.'")
+    end
+    if e.message:findi("specific order") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'There exist three temples nearby that you must enter. I have defined these three as the Temple of [" .. eq.say_link("Singular Might") .. "], Temple of [" .. eq.say_link("Twin Struggles") .. "], and Temple of the [" .. eq.say_link("Tri-Fates") .. "]. In each lay the forces of the Legion of Mata Muram who must be destroyed. You must not be fooled, we do not control these temples. The areas are controlled by the [" .. eq.say_link("Muramites") .. "], but we believe that these places hold the most predictable of the invaders and can be used easily as our testing grounds.'")
+    end
+    if e.message:findi("muramites") then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'The Muramites aren't from Norrath. We're not sure where they're from yet, but that's one of the things we're trying to uncover. They are part of the Legion of Mata Muram, and though we don't know who Mata Muram is just yet, we believe he is their leader. Back to the issue at hand, the Muramites keep a steady flow of reinforcements into these three temples to ensure that they maintain control of them. We use the temples to ensure that we have capable expeditioners to eradicate more of the creatures that serve in the legion.'")
+    end
+  end
+end
+
+function event_trade(e)
+  local kt_flag = tonumber(e.other:GetAccountBucket("god.flags.kt")) or 0
+  local item_lib = require("items")
+
+  if item_lib.check_turn_in(e.trade, {item1 = 60141, item2 = 60142, item3 = 60143, item4 = 60144}) and kt_flag == 11 then
+    e.other:Message(MT.NPCQuestSay, "Kevren examines the relics for a moment. 'The only thing I can find on these relics are glyphs. They're very old and hard to make out, but it appears that they depict four powers. I would say they refer to the temples around the Altar of Destruction, but I can't be sure. It will take some time to go over these some more. In the meantime, do you have anything else for me that might explain the Muramites' interest in the passage? If not, please do go look again. I'm sure there will be something there we can use!'")
+    e.other:Message(MT.LightBlue, "Finished! - You've returned four relics from the Martyrs Passage!")
+    e.other:SetAccountBucket("god.flags.kt", "12")
+  end
+
+  if item_lib.check_turn_in(e.trade, {item1 = 60145}) and kt_flag == 12 then
+    e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Aha! I suspected there would be some kind of indication of what they were doing in that passage. I applaud your efforts. I only briefly skimmed the information and from what I can gather, it appears that there are nefarious deeds afoot. I'll need more time to examine this, but I should know what it says in a few moments. Well done, once again, " .. e.other:GetCleanName() .. "!'")
+    e.other:Message(MT.LightBlue, "Finished! - You've returned valuable information as to why the Muramites are in the Martyrs Passage!");
+    e.other:SetAccountBucket("god.flags.kt", "13")
+  end
+
+  if item_lib.check_turn_in(e.trade, {item1 = 60146, item2 = 60147, item3 = 60148, item4 = 60149}) and kt_flag == 14 then
+    e.other:Message(MT.NPCQuestSay, "Kevren examines the strange glyphs. 'These glyphs are faded. I won't be able to decipher them until they've been cleaned up. You'll need to go back to the Martyrs Passage and recover some dust from the grounds nearby. Once you've gotten a pile of dust, you'll need to speak with Tublik Narwethar who is south of the Martyrs Passage. He has a stone tablet that can add some clarity to the glyphs with the help of that dust. Hurry along, " .. e.other:GetCleanName() .. ", this information is important!'")
+    e.other:SummonItem(60146)
+    e.other:SummonItem(60147)
+    e.other:SummonItem(60148)
+    e.other:SummonItem(60149)
+    e.other:Message(MT.LightBlue, "Finished! - You've recovered important glyphs from the Temple of the Damned!")
+    e.other:SetAccountBucket("god.flags.kt", "15")
+  end
+
+  if item_lib.check_turn_in(e.trade, {item1 = 60150}) and kt_flag == 17 then
+    e.other:Message(MT.NPCQuestSay, "Kevren copies down the intricate patterns from the glyph. 'Very interesting, but very dangerous. I've gone over the glyphs and they suggest there is great danger in the summoning of some kind of ferocious beast. I need to study the markings further, but since I've transcribed them already, you can keep the glyph for your own use. Nicely done, " .. e.other:GetCleanName() .. ".'")
+    e.other:SummonItem(60150)
+    e.other:Message(MT.LightBlue, "Finished! - You've successfully translated the glyphs you found in the Temple of the Damned.")
+    e.other:SetAccountBucket("god.flags.kt", "18")
+  end
+
+  if item_lib.check_turn_in(e.trade, {item = 60151}) and kt_flag == 18 then
+    e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'You've done well to stop the summoning, " .. e.other:GetCleanName() .. ". I know it wasn't easy, but you are quickly becoming known as someone who can do what needs to get done. I fear I have run out of things for you to do for now, so you must find Tublik Narwethar and speak with him for further tasks to complete. You can find him to the south of the Martyrs Passage. Farewell for now, " .. e.other:GetCleanName() .. ".'")
+    e.other:Message(MT.LightBlue, "Finished! - You were able to recover a rare artifact from the Grand Summoner's goons in the Summoning Circle!")
+  end
+
+  --TODO: Add the bic turnin
+
+  item_lib.return_items(e.self, e.other, e.trade)
+end

--- a/kodtaz/Kevren_Nalavat.lua
+++ b/kodtaz/Kevren_Nalavat.lua
@@ -33,7 +33,7 @@ function event_say(e)
   -- Flag 17: Summoner's Ring
   if kt_flag == 17 then
     if e.message:findi("hail") then
-      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Welcome back, " .. e.other:GetCleanName() .. ". I've studied the glyph as much as I can for now. In addition to what we uncovered with the translated glyph, we've received word that the [" .. eq.say_link("rumors") .. "] of a dark summoning are indeed true. The truth of these rumors is no surprise to me at all with all that we've uncovered thus far. The Legion of Mata Muram is evil indeed I have a moment if you want to talk a bit [" .. eq.say_link("more") .. "] about me. You're also more than welcome to attempt the trials again. If so, just let me know you're [" .. eq.say_link("ready to test") "] again and we'll proceed down that path. What'll it be, " .. e.other:GetCleanName() .. "?")
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Welcome back, " .. e.other:GetCleanName() .. ". I've studied the glyph as much as I can for now. In addition to what we uncovered with the translated glyph, we've received word that the [" .. eq.say_link("rumors") .. "] of a dark summoning are indeed true. The truth of these rumors is no surprise to me at all with all that we've uncovered thus far. The Legion of Mata Muram is evil indeed I have a moment if you want to talk a bit [" .. eq.say_link("more") .. "] about me. You're also more than welcome to attempt the trials again. If so, just let me know you're [" .. eq.say_link("ready to test") .. "] again and we'll proceed down that path. What'll it be, " .. e.other:GetCleanName() .. "?")
     end
     if e.message:findi("rumors") then
       e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'It looks as though the invaders are planning on bringing beasts into this world by means of a collective summoning. We're unsure if they're even able to do this, but we do know that they cannot be allowed the chance to succeed. You are charged with finding the Muramites attempting this summoning and putting a stop to them at once! Is this something you [" .. eq.say_link("think you can do") .. "]?'")
@@ -42,7 +42,7 @@ function event_say(e)
       e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'I hoped as much. What I ask of you now won't be easy. You must gather a raiding force several times the size of your normal party. We fear that only sufficient force will be enough to stop this threat. Once you have your party in tow, make your way to the summoning circle, and vanquish the threat of the evil legion priests before they bring their minions into this realm. I have one [" .. eq.say_link("final warning") .. "] for you before you go.'")
     end
     if e.message:findi("final warning") then
-      e.other:Message(MT.NPCQuestSya, "Kevren Nalavat says 'I am unsure of the Muramites' timing. It is possible that I have heard incorrectly and that the summoning force may not be there at this time. Do not take this to mean that I was wrong! The force will be there, but it may take them a few more hours to assemble. Be patient. They will arrive. Lastly, the rumors have stated that these legion priests will be using some special artifacts they have collected. We do not know what these artifacts are, but you must return one of these artifacts to me when you have finished so that we can examine it. Good luck, " .. e.other:GetCleanName() .. ", I fear you may need it.'")
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'I am unsure of the Muramites' timing. It is possible that I have heard incorrectly and that the summoning force may not be there at this time. Do not take this to mean that I was wrong! The force will be there, but it may take them a few more hours to assemble. Be patient. They will arrive. Lastly, the rumors have stated that these legion priests will be using some special artifacts they have collected. We do not know what these artifacts are, but you must return one of these artifacts to me when you have finished so that we can examine it. Good luck, " .. e.other:GetCleanName() .. ", I fear you may need it.'")
       e.other:SetAccountBucket("god.flags.kt", "18")
     end
   end
@@ -71,7 +71,7 @@ function event_say(e)
   --Flag 13: Temple of the Damned
   if kt_flag == 13 then
     if e.message:findi("hail") then
-       e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Hello again, " .. e.other:GetCleanName() .. ". I've been studying the information you retrieved from the Martyrs Passage and I do believe we have a [" .. eq.say_link("problem") .. "] on our hands. I have a moment if you want to talk a bit [" .. eq.say_link("more") .. "] about me. You're also more than welcome to attempt the trials again. If so, just let me know you're [" .. eq.say_link("ready to test") "] again and we'll proceed down that path. What'll it be, " .. e.other:GetCleanName() .. "?")
+       e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Hello again, " .. e.other:GetCleanName() .. ". I've been studying the information you retrieved from the Martyrs Passage and I do believe we have a [" .. eq.say_link("problem") .. "] on our hands. I have a moment if you want to talk a bit [" .. eq.say_link("more") .. "] about me. You're also more than welcome to attempt the trials again. If so, just let me know you're [" .. eq.say_link("ready to test") .. "] again and we'll proceed down that path. What'll it be, " .. e.other:GetCleanName() .. "?")
     end
     if e.message:findi("problem") then
       e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'The problem is that this information reveals a most disturbing plot by the Muramites to summon a creature into this realm. They appear to be experts in teleportation. The parchment you returned to me described the use of the Temple of the Damned to gather instruments of power that will allow the beast to coalesce in our world. It doesn't go into what those instruments are or when the summoning will take place, so you must [" .. eq.say_link("discover their plans") .. "].'")
@@ -102,10 +102,10 @@ function event_say(e)
       e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Welcome back, " .. e.other:GetCleanName() ..". I must congratulate you on your recent completion of all three trials. I must admit that I was unsure of your ability to do as well as you did. Now that you have finished, you have the choice of taking on some [" .. eq.say_link("other tasks") .. "]. If you'd like, we have a chance now to talk [" .. eq.say_link("more") .. "]. You're also more than welcome to attempt the trials again. If so, just let me know you're [" .. eq.say_link("ready to test") .. "] again and we'll proceed down that path. What'll it be, " .. e.other:GetCleanName() .. "?'")
     end
     if e.message:findi("other tasks") then
-      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'As I suspected, you're ready for some challenging work! I must warn you though, what lies ahead is not for the faint of heart.  The task I need now is someone to investigate the[" .. eq.say_link("Martyrs Passage") .. "].")
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'As I suspected, you're ready for some challenging work! I must warn you though, what lies ahead is not for the faint of heart.  The task I need now is someone to investigate the [" .. eq.say_link("Martyrs Passage") .. "].")
     end
     if e.message:findi("martyrs passage") then
-      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Good, we're in need of a sturdy adventurer to help us with a dire situation along the Martyrs Passage. First, this area was named so because it houses the spirits of martyred heroes lost long ago. The trusik lined the passageway with [" .. eq.say_link("ancient relics") "] to sooth the spirits while in the afterlife. Unfortunately, the Muramites are disturbing the remains and are looking to collect the spiritual remnants for some sinister use.'")
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Good, we're in need of a sturdy adventurer to help us with a dire situation along the Martyrs Passage. First, this area was named so because it houses the spirits of martyred heroes lost long ago. The trusik lined the passageway with [" .. eq.say_link("ancient relics") .. "] to sooth the spirits while in the afterlife. Unfortunately, the Muramites are disturbing the remains and are looking to collect the spiritual remnants for some sinister use.'")
     end
     if e.message:findi("ancient relics") then
       e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'We're unsure what the invaders are gathering these particular relics for. From what I can surmise, none of them have any kind of magical properties. In any case, it's up to you and a group of adventurers to venture to the Martyrs Passage and [" .. eq.say_link("investigate") .. "] the situation. I've heard reports of ghosts in that area, so the invaders may have stirred up something unexpected.'")
@@ -122,7 +122,7 @@ function event_say(e)
   --Flag 8 and 9: You should be doing the trial
   if kt_flag == 8 or kt_flag == 9 then
     if e.message:findi("hail") then
-      e.other:Message(MT.NPCQuestSay, "Kevran Nalavat says, 'Good luck with the third trial, " .. e.other:GetCleanName() .. "!  Be sure to return the artifact you obtain from the trial to Maroley Nazuey.")
+      e.other:Message(MT.NPCQuestSay, "Kevran Nalavat says, 'Good luck with the third trial, " .. e.other:GetCleanName() .. "!  Be sure to return the artifact you obtain from the trial to Kenra Kalekkio.")
     end
   end
 
@@ -134,7 +134,7 @@ function event_say(e)
     if e.message:findi("singular might") or e.message:findi("twin struggles") then
       e.other:Message(MT.NPCQuestSay, "Kevren Nalavat shakes his head, 'You have already completed that trial, the brotherhood needs you to move on to the next challenges before you can return to a trial.")
     end
-    if e.message:findi("tri-fates") then
+    if e.message:findi("tri(.*)fates") then
       e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Beyond the dark fog to the south lies the Temple of the Tri-Fates. It is the northern-most temple of the three. In front of the temple you will encounter three smaller temples and it is there you will find another of the brotherhood waiting for you. Seek out and speak with Kenra Kalekkio about the troubles within the temple.'")
       e.other:SetAccountBucket("god.flags.kt", "8")
     end
@@ -159,7 +159,7 @@ function event_say(e)
     if e.message:findi("singular might") then
       e.other:Message(MT.NPCQuestSay, "Kevren Nalavat shakes his head, 'You have already completed that trial, the brotherhood needs you to move on to the next challenges before you can return to a trial.")
     end
-    if e.message:findi("tri-fates") then
+    if e.message:findi("tri(.*)fates") then
       e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'I'm sorry " .. e.other:GetCleanName() .. ", but you're not ready to face the third trial. You must first find Maroley Nazuey near the Temple of [" .. eq.say_link("Twin Struggles") .. "] and finish the second trial before you may proceed. Return to me when you have accomplished that feat.'")
     end
   end
@@ -183,13 +183,13 @@ function event_say(e)
     if e.message:findi("twin struggles") then
       e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'I'm sorry " .. e.other:GetCleanName() .. ", but you're not ready to face the second trial. You must first find Gazak Klelkek near the Temple of [" .. eq.say_link("Singular Might") .. "] and finish the first trial before you may proceed. Return to me when you have accomplished that feat.'")
     end
-    if e.message:findi("tri-fates") then
+    if e.message:findi("tri(.*)fates") then
       e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'I'm sorry " .. e.other:GetCleanName() .. ", but you're not ready to face the third trial. You must first find Gazak Klelkek near the Temple of [" .. eq.say_link("Singular Might") .. "] and finish the first trial before you may proceed. Return to me when you have accomplished that feat.'")
     end
   end
 
   --Flags 10 and up: Redo trials
-  if kt_flag >= 11 then
+  if kt_flag >= 10 then
     if e.message:findi("ready to test") then
       e.other:Message(MT.NPCQuestSay, "Kevren nods his approval, 'Good to hear! If you're interested or have forgotten I can give you some [" .. eq.say_link("background information") .. "] about the mountaintop. If you're ready to proceed, I can explain the [" .. eq.say_link("trials") .. "] to you once more.'")
     end
@@ -208,7 +208,7 @@ function event_say(e)
       e.other:Message(MT.Yellow, "Kevren Nalavat says 'If you want to see what you've completed at any time, just ask me for a [" .. eq.say_link("progress update") .. "]!'") 
     end
     if e.message:findi("progress update") then
-      if kt_flag >= 11 then
+      if kt_flag >= 10 then
 	e.other:Message(MT.Yellow, "Finished! - You can now retry any of the trials at any time!")
       end
       if kt_flag == 2 or kt_flag == 3 then
@@ -349,38 +349,59 @@ function event_trade(e)
   local kt_flag = tonumber(e.other:GetAccountBucket("god.flags.kt")) or 0
   local item_lib = require("items")
 
-  if item_lib.check_turn_in(e.trade, {item1 = 60141, item2 = 60142, item3 = 60143, item4 = 60144}) and kt_flag == 11 then
-    e.other:Message(MT.NPCQuestSay, "Kevren examines the relics for a moment. 'The only thing I can find on these relics are glyphs. They're very old and hard to make out, but it appears that they depict four powers. I would say they refer to the temples around the Altar of Destruction, but I can't be sure. It will take some time to go over these some more. In the meantime, do you have anything else for me that might explain the Muramites' interest in the passage? If not, please do go look again. I'm sure there will be something there we can use!'")
-    e.other:Message(MT.LightBlue, "Finished! - You've returned four relics from the Martyrs Passage!")
-    e.other:SetAccountBucket("god.flags.kt", "12")
+  if item_lib.check_turn_in(e.trade, {item1 = 60141, item2 = 60142, item3 = 60143, item4 = 60144}) then
+    if kt_flag == 11 then
+      e.other:Message(MT.NPCQuestSay, "Kevren examines the relics for a moment. 'The only thing I can find on these relics are glyphs. They're very old and hard to make out, but it appears that they depict four powers. I would say they refer to the temples around the Altar of Destruction, but I can't be sure. It will take some time to go over these some more. In the meantime, do you have anything else for me that might explain the Muramites' interest in the passage? If not, please do go look again. I'm sure there will be something there we can use!'")
+      e.other:Message(MT.LightBlue, "Finished! - You've returned four relics from the Martyrs Passage!")
+      e.other:SetAccountBucket("god.flags.kt", "12")
+    else
+      item_lib.return_items(e.self, e.other, e.trade)
+    end
   end
 
-  if item_lib.check_turn_in(e.trade, {item1 = 60145}) and kt_flag == 12 then
-    e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Aha! I suspected there would be some kind of indication of what they were doing in that passage. I applaud your efforts. I only briefly skimmed the information and from what I can gather, it appears that there are nefarious deeds afoot. I'll need more time to examine this, but I should know what it says in a few moments. Well done, once again, " .. e.other:GetCleanName() .. "!'")
-    e.other:Message(MT.LightBlue, "Finished! - You've returned valuable information as to why the Muramites are in the Martyrs Passage!");
-    e.other:SetAccountBucket("god.flags.kt", "13")
+  if item_lib.check_turn_in(e.trade, {item1 = 60145}) then
+    if kt_flag == 12 then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'Aha! I suspected there would be some kind of indication of what they were doing in that passage. I applaud your efforts. I only briefly skimmed the information and from what I can gather, it appears that there are nefarious deeds afoot. I'll need more time to examine this, but I should know what it says in a few moments. Well done, once again, " .. e.other:GetCleanName() .. "!'")
+      e.other:Message(MT.LightBlue, "Finished! - You've returned valuable information as to why the Muramites are in the Martyrs Passage!");
+      e.other:SetAccountBucket("god.flags.kt", "13")
+    else
+      item_lib.return_items(e.self, e.other, e.trade)
+    end
   end
 
-  if item_lib.check_turn_in(e.trade, {item1 = 60146, item2 = 60147, item3 = 60148, item4 = 60149}) and kt_flag == 14 then
-    e.other:Message(MT.NPCQuestSay, "Kevren examines the strange glyphs. 'These glyphs are faded. I won't be able to decipher them until they've been cleaned up. You'll need to go back to the Martyrs Passage and recover some dust from the grounds nearby. Once you've gotten a pile of dust, you'll need to speak with Tublik Narwethar who is south of the Martyrs Passage. He has a stone tablet that can add some clarity to the glyphs with the help of that dust. Hurry along, " .. e.other:GetCleanName() .. ", this information is important!'")
-    e.other:SummonItem(60146)
-    e.other:SummonItem(60147)
-    e.other:SummonItem(60148)
-    e.other:SummonItem(60149)
-    e.other:Message(MT.LightBlue, "Finished! - You've recovered important glyphs from the Temple of the Damned!")
-    e.other:SetAccountBucket("god.flags.kt", "15")
+  if item_lib.check_turn_in(e.trade, {item1 = 60146, item2 = 60147, item3 = 60148, item4 = 60149}) then 
+    if kt_flag == 14 then
+      e.other:Message(MT.NPCQuestSay, "Kevren examines the strange glyphs. 'These glyphs are faded. I won't be able to decipher them until they've been cleaned up. You'll need to go back to the Martyrs Passage and recover some dust from the grounds nearby. Once you've gotten a pile of dust, you'll need to speak with Tublik Narwethar who is south of the Martyrs Passage. He has a stone tablet that can add some clarity to the glyphs with the help of that dust. Hurry along, " .. e.other:GetCleanName() .. ", this information is important!'")
+      e.other:SummonItem(60146)
+      e.other:SummonItem(60147)
+      e.other:SummonItem(60148)
+      e.other:SummonItem(60149)
+      e.other:Message(MT.LightBlue, "Finished! - You've recovered important glyphs from the Temple of the Damned!")
+      e.other:SetAccountBucket("god.flags.kt", "15")
+    else
+      item_lib.return_items(e.self, e.other, e.trade)
+    end
   end
 
-  if item_lib.check_turn_in(e.trade, {item1 = 60150}) and kt_flag == 17 then
-    e.other:Message(MT.NPCQuestSay, "Kevren copies down the intricate patterns from the glyph. 'Very interesting, but very dangerous. I've gone over the glyphs and they suggest there is great danger in the summoning of some kind of ferocious beast. I need to study the markings further, but since I've transcribed them already, you can keep the glyph for your own use. Nicely done, " .. e.other:GetCleanName() .. ".'")
-    e.other:SummonItem(60150)
-    e.other:Message(MT.LightBlue, "Finished! - You've successfully translated the glyphs you found in the Temple of the Damned.")
-    e.other:SetAccountBucket("god.flags.kt", "18")
+  if item_lib.check_turn_in(e.trade, {item1 = 60150}) then
+    if kt_flag == 16 then
+      e.other:Message(MT.NPCQuestSay, "Kevren copies down the intricate patterns from the glyph. 'Very interesting, but very dangerous. I've gone over the glyphs and they suggest there is great danger in the summoning of some kind of ferocious beast. I need to study the markings further, but since I've transcribed them already, you can keep the glyph for your own use. Nicely done, " .. e.other:GetCleanName() .. ".'")
+      e.other:SummonItem(60150)
+      e.other:Message(MT.LightBlue, "Finished! - You've successfully translated the glyphs you found in the Temple of the Damned.")
+      e.other:SetAccountBucket("god.flags.kt", "17")
+    else
+      item_lib.return_items(e.self, e.other, e.trade)
+    end
   end
 
-  if item_lib.check_turn_in(e.trade, {item = 60151}) and kt_flag == 18 then
-    e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'You've done well to stop the summoning, " .. e.other:GetCleanName() .. ". I know it wasn't easy, but you are quickly becoming known as someone who can do what needs to get done. I fear I have run out of things for you to do for now, so you must find Tublik Narwethar and speak with him for further tasks to complete. You can find him to the south of the Martyrs Passage. Farewell for now, " .. e.other:GetCleanName() .. ".'")
-    e.other:Message(MT.LightBlue, "Finished! - You were able to recover a rare artifact from the Grand Summoner's goons in the Summoning Circle!")
+  if item_lib.check_turn_in(e.trade, {item1 = 60151}) then
+    if kt_flag == 18 then
+      e.other:Message(MT.NPCQuestSay, "Kevren Nalavat says 'You've done well to stop the summoning, " .. e.other:GetCleanName() .. ". I know it wasn't easy, but you are quickly becoming known as someone who can do what needs to get done. I fear I have run out of things for you to do for now, so you must find Tublik Narwethar and speak with him for further tasks to complete. You can find him to the south of the Martyrs Passage. Farewell for now, " .. e.other:GetCleanName() .. ".'")
+      e.other:Message(MT.LightBlue, "Finished! - You were able to recover a rare artifact from the Grand Summoner's goons in the Summoning Circle!")
+      e.other:SetAccountBucket("god.flags.kt", "19")
+    else
+      item_lib.return_items(e.self, e.other, e.trade)
+    end
   end
 
   --TODO: Add the bic turnin

--- a/kodtaz/Kevren_Nalavat.lua
+++ b/kodtaz/Kevren_Nalavat.lua
@@ -205,11 +205,11 @@ function event_say(e)
   --Flags 2 and up: Progress Report
   if kt_flag >= 2 then
     if e.message:findi("hail") then
-      e.other:Message(MT.Yellow, "Kevren Nalavat says 'If you want to see what you've completed at any time, just ask me for a [" .. eq.say_link("progress update") .. "]!'") 
+      e.other:Message(MT.Yellow, "Tublik Narwethar says 'If you want to see what you've completed at any time, just ask me for a [" .. eq.say_link("progress update") .. "]!'")
     end
     if e.message:findi("progress update") then
       if kt_flag >= 10 then
-	e.other:Message(MT.Yellow, "Finished! - You can now retry any of the trials at any time!")
+        e.other:Message(MT.Yellow, "Finished! - You can now retry any of the trials at any time!")
       end
       if kt_flag == 2 or kt_flag == 3 then
         e.other:Message(MT.Yellow, "Pending - You have been commissioned by Kevran Nalavat to undertake the Trial of Singular Might.")
@@ -217,80 +217,92 @@ function event_say(e)
         e.other:Message(MT.Yellow, "Finished! - You have completed the trial at the Temple of Singular Might!")
       end
       if kt_flag == 5 or kt_flag == 6 then
-	e.other:Message(MT.Yellow, "Pending - You have been commissioned by Kevran Nalavat to undertake the Trial of Twin Struggles.")
+        e.other:Message(MT.Yellow, "Pending - You have been commissioned by Kevran Nalavat to undertake the Trial of Twin Struggles.")
       elseif kt_flag >= 7 then
         e.other:Message(MT.Yellow, "Finished! - You have completed the trial at the Temple of Twin Struggles!")
       end
       if kt_flag == 8 or kt_flag == 9 then
         e.other:Message(MT.Yellow, "Pending - You have been commissioned by Kevran Nalavat to undertake the Trial of Tri-Fates")
       elseif kt_flag >= 10 then
-	e.other:Message(MT.Yellow, "Finished! - You have completed the trial at the Temple of Tri-Fates!")
+        e.other:Message(MT.Yellow, "Finished! - You have completed the trial at the Temple of Tri-Fates!")
       end
       if kt_flag == 11 then
         e.other:Message(MT.Yellow, "Pending - You have been commissioned by Kevran Nalavat to investigate the Martyrs Passage.")
       end
       if kt_flag >= 12 then
-	e.other:Message(MT.Yellow, "Finished! - You returned four relics from the Martyrs Passage!")
+        e.other:Message(MT.Yellow, "Finished! - You returned four relics from the Martyrs Passage!")
       end
       if kt_flag == 12 then
-	e.other:Message(MT.Yellow, "Pending - You haven't yet returned any information as to why the Muramites are in Martyrs Passage.")
+        e.other:Message(MT.Yellow, "Pending - You haven't yet returned any information as to why the Muramites are in Martyrs Passage.")
       end
       if kt_flag >= 13 then
-	e.other:Message(MT.Yellow, "Finished! - You returned valuable information as to why the Muramites are in the Martyrs Passage!")
+        e.other:Message(MT.Yellow, "Finished! - You returned valuable information as to why the Muramites are in the Martyrs Passage!")
       end
       if kt_flag >= 14 then
-	e.other:Message(MT.Yellow, "Finished! - You've been comissioned to investigate the Temple of the Damned.")
+        e.other:Message(MT.Yellow, "Finished! - You've been comissioned to investigate the Temple of the Damned.")
       end
       if kt_flag >= 15 then
-	e.other:Message(MT.Yellow, "Finished! - You've recovered important glyphs from the Temple of the Damned!")
+        e.other:Message(MT.Yellow, "Finished! - You've recovered important glyphs from the Temple of the Damned!")
       end
       if kt_flag == 15 or kt_flag == 16 then
         e.other:Message(MT.Yellow, "Pending - You haven't translated the glyphs gathered from the Temple of the Damned.")
       end
       if kt_flag >= 17 then
-	e.other:Message(MT.Yellow, "Finished! - You've successfully translated the glyphs you found in the Temple of the Damned!")
+        e.other:Message(MT.Yellow, "Finished! - You've successfully translated the glyphs you found in the Temple of the Damned!")
       end
       if kt_flag >= 18 then
-	e.other:Message(MT.Yellow, "Finished! - You've been charged with stopping the ceremony at the Summoning Circle!")
+        e.other:Message(MT.Yellow, "Finished! - You've been charged with stopping the ceremony at the Summoning Circle!")
       end
       if kt_flag >= 19 then
-	e.other:Message(MT.Yellow, "Finished! - You were able to recover a rare artifact from the Grand Summoner's goons in the Summoning Circle!")
+        e.other:Message(MT.Yellow, "Finished! - You were able to recover a rare artifact from the Grand Summoner's goons in the Summoning Circle!")
       end
-      if kt_flag >= 20 then
-	e.other:Message(MT.Yellow, "Finished! - You've been sent to gather any clues you can find from the Crumbled Sanctuary of Divine Destruction!")
+      if kt_flag == 20 then
+        e.other:Message(MT.Yellow, "Pending - You've been tasked by Tublik Narwether to investigate the Pit of the Lost and recover relics.")
       end
       if kt_flag >= 21 then
-	e.other:Message(MT.Yellow, "Finished! - You have collected the four Frayed Flesh Scraps from the Crumbled Sanctuary of Divine Destruction!")
+        e.other:Message(MT.Yellow, "Finished! - You've collected the Minor Relics of Power from the Pit of the Lost!")
       end
-      if kt_flag >= 22 then
-	e.other:Message(MT.Yellow, "Finished! - You've sewn the flesh scraps together to make the Sewn Flesh Parchment!")
+      if kt_flag == 22 then
+        e.other:Message(MT.Yellow, "Pending - You;ve been tasked by Tublik Narwether to investigate a disturbance at the Pit of the Lost.")
       end
       if kt_flag >= 23 then
-	e.other:Message(MT.Yellow, "Finished! - You've found the three clues from the three trial temples!")
+        e.other:Message(MT.Yellow, "Finished! - You've rescued the artifact from the Ageless Relic Protector in the Pit of the Lost!")
       end
       if kt_flag >= 24 then
-	e.other:Message(MT.Yellow, "Finished! - You've recovered the Artifact of Righteousness!")
+        e.other:Message(MT.Yellow, "Finished! - You've been sent to gather any clues you can find from the Crumbled Sanctuary of Divine Destruction!")
       end
       if kt_flag >= 25 then
-	e.other:Message(MT.Yellow, "Finished! - You've recovered the Artifact of Glorification!")
+        e.other:Message(MT.Yellow, "Finished! - You have collected the four Frayed Flesh Scraps from the Crumbled Sanctuary of Divine Destruction!")
       end
       if kt_flag >= 26 then
-	e.other:Message(MT.Yellow, "Finished! - You've recovered the Artifact of Transcendence!")
+        e.other:Message(MT.Yellow, "Finished! - You've sewn the flesh scraps together to make the Sewn Flesh Parchment!")
       end
       if kt_flag >= 27 then
-	e.other:Message(MT.Yellow, "Finished! - You've been instructed on what needs to be done to make the Icon of the Altar!")
+        e.other:Message(MT.Yellow, "Finished! - You've found the three clues from the three trial temples!")
       end
       if kt_flag >= 28 then
-	e.other:Message(MT.Yellow, "Finished! - You've constructed your Icon of the Altar!")
+        e.other:Message(MT.Yellow, "Finished! - You've recovered the Artifact of Righteousness!")
       end
       if kt_flag >= 29 then
+        e.other:Message(MT.Yellow, "Finished! - You've recovered the Artifact of Glorification!")
+      end
+      if kt_flag >= 30 then
+        e.other:Message(MT.Yellow, "Finished! - You've recovered the Artifact of Transcendence!")
+      end
+      if kt_flag >= 31 then
+        e.other:Message(MT.Yellow, "Finished! - You've been instructed on what needs to be done to make the Icon of the Altar!")
+      end
+      if kt_flag >= 32 then
+        e.other:Message(MT.Yellow, "Finished! - You've constructed your Icon of the Altar!")
+      end
+      if kt_flag >= 33 then
         e.other:Message(MT.Yellow, "You have obtained a Sliver of the High Temple!  Congratulations!")
       end
-      if kt_flag == 30 then
-	e.other:Message(MT.Yellow, "The barrier to Qvic has been breeched by your possession of the Sliver of the High Temple and the Fragment of the High Temple!")
+      if kt_flag == 34 then
+        e.other:Message(MT.Yellow, "The barrier to Qvic has been breeched by your possession of the Sliver of the High Temple and the Fragment of the High Temple!")
       end
-      if kt_flag < 30 then
-	e.other:Message(MT.Yellow, "Kod'taz still has secrets to discover...")
+      if kt_flag < 33 then
+        e.other:Message(MT.Yellow, "Kod'taz still has secrets to discover...")
       end
     end
   end

--- a/kodtaz/Maroley_Nazuey.lua
+++ b/kodtaz/Maroley_Nazuey.lua
@@ -16,11 +16,10 @@ function event_say(e)
   local qglobals = eq.get_qglobals(e.other);
 
   local is_gm = (e.other:Admin() > 80 and e.other:GetGM())
-  local has_kevren_flag = (is_gm or (tonumber(qglobals.ikky) and tonumber(qglobals.ikky) >= 1))
-  local finished_first_trial = (is_gm or (tonumber(qglobals.ikky) and tonumber(qglobals.ikky) >= 2))
-  local finished_second_trial = (tonumber(qglobals.ikky) and tonumber(qglobals.ikky) >= 3)
-
-  local preflag_key = string.format("%s-ikkinz_group2_maroley", e.other:CharacterID())
+  local kt_flag = tonumber(e.other:GetAccountBucket("god.flags.kt")) or 0
+  local has_kevren_flag = (is_gm or kt_flag >= 2)
+  local finished_first_trial = (is_gm or kt_flag >= 4)
+  local finished_second_trial = (kt_flag >= 7)
 
   if e.message:findi("hail") then
     if not has_kevren_flag then
@@ -63,14 +62,17 @@ function event_say(e)
       e.other:Message(MT.NPCQuestSay, "Maroley Nazuey says, 'I'm afraid I can't allow you to attempt to recover any artifacts for me until you're finished the first trial. You need to find Gazak Klelkek first. Maybe after you've completed the first trial we can talk about artifacts.'")
     else
       e.other:Message(MT.NPCQuestSay, ("Maroley Nazuey says, 'This is your moment, %s. Now is the time to prove your worth to the brotherhood. I bid you good luck and hope that the strength you showed in the first trial will aid you again in your second one. When you are [" .. eq.say_link("ready to enter the temple") .. "] and have a group with you, return to me and I shall set you on your way.'"):format(e.other:GetCleanName()))
-      eq.set_data(preflag_key, "1")
+      if kt_flag == 5 then
+        e.other:SetAccountBucket("god.flags.kt", "6")
+	kt_flag = 6
+      end
     end
   elseif e.message:findi("ready(.*)enter(.*)temple") then
     if not has_kevren_flag then
       e.other:Message(MT.NPCQuestSay, "Maroley Nazuey says, 'No, I don't believe you are ready to enter this temple. You haven't even begun your preparations to start the first trial, let alone enter this temple. You must find Kevren Nalavat to the north and speak to him about the trials first.'")
     elseif not finished_first_trial then
       e.other:Message(MT.NPCQuestSay, "Maroley Nazuey says, 'I imagine you may think you're ready to enter this temple, but I can assure you that you are not. You must complete the first trial before you will be allowed entrance to this temple. Seek out Gazak Klelkek at the Temple of Singular Might for more information on the first trial.'")
-    elseif not is_gm and eq.get_data(preflag_key) == "" then
+    elseif not is_gm and kt_flag == 5 then
       e.other:Message(MT.NPCQuestSay, "Maroley Nazuey says, 'What's that you say? You're ready to enter this temple? I don't remember speaking to you about [" .. eq.say_link("what's in store") .. "] for you here.'")
     elseif not is_gm and e.other:DoesAnyPartyMemberHaveLockout(expedition_name, "Replay Timer", 6) then
       e.other:Message(MT.NPCQuestSay, "Maroley Nazuey says, 'I'm afraid I cannot allow you to begin, someone in your party has been on this expedition too recently and cannot yet go again.'")
@@ -87,9 +89,10 @@ end
 function event_trade(e)
   -- load the current qglobals
   local qglobals = eq.get_qglobals(e.other);
-  local has_kevren_flag = (tonumber(qglobals.ikky) and tonumber(qglobals.ikky) >= 1)
-  local finished_first_trial = (tonumber(qglobals.ikky) and tonumber(qglobals.ikky) >= 2)
-  local finished_second_trial = (tonumber(qglobals.ikky) and tonumber(qglobals.ikky) >= 3)
+  local kt_flag = tonumber(e.other:GetAccountBucket("god.flags.kt")) or 0
+  local has_kevren_flag = (is_gm or kt_flag >= 2)
+  local finished_first_trial = (is_gm or kt_flag >= 4)
+  local finished_second_trial = (kt_flag >= 7)
 
   local item_lib = require("items")
 
@@ -103,7 +106,7 @@ function event_trade(e)
     else
       e.other:Message(MT.NPCQuestSay, string.format("Maroley Nazuey says, 'You've done well, %s. I believed this temple was more than you could handle despite your success with the first temple. You faced two enemies at once and came back in one piece. You only have one trial left to complete before you can proceed onto more difficult tasks. Please return to Kevren for information on the final trial. Good luck!'", e.other:GetCleanName()))
       if not finished_second_trial then
-        eq.set_global("ikky", "3", 5, "F")
+	e.other:SetAccountBucket("god.flags.kt", "7")
         e.other:AddEXP(1)
       end
     end

--- a/kodtaz/Sentinel_of_the_Altar.lua
+++ b/kodtaz/Sentinel_of_the_Altar.lua
@@ -1,0 +1,34 @@
+function event_say(e)
+  local kt_flag = tonumber(e.other:GetAccountbucket("god.flags.kt")) or 0
+  if e.message:findi('hail') then
+    if kt_flag <= 32 then
+      e.message(MT.NPCQuestSay, "The Sentinel of the Altar ignores your every attempt to interact with it.")
+    else
+      get_expedition(e)
+    end
+  end
+
+function event_trade(e)
+  local kt_flag = tonumber(e.other:GetAccountBucket("god.flags.kt")) or 0
+  local item_lib = require("items")
+  if item_lib.check_turn_in(e.trade, {item1 = 60173}) and kt_flag == 32 then
+    get_expedition(e)
+  end
+  
+  item_lib.return_items(e.self, e.other, e.trade)
+end
+
+function get_expedition(e)
+  local dz_info = {
+    expedition = { name="Ikkinz, Antechamber of Destruction", min_players=1, max_players=6 },
+    instance = { zone="ikkinz", version=6, duration=eq.seconds("13h") },
+    compass = { zone="kodtaz", x=1860, y=660, z=-447 },
+    safereturn = { zone="kodtaz", x=1279, y=-2004, z=-349.375, h=336 },
+    zonein = { x=1860, y=660, z=-447, h=0 },
+  }
+  local dz = e.other:CreateExpedition(dz_info)
+  if dz.valid then
+    dz.AddReplayLockout(eq.seconds("14h"))
+    e.other:Message(MT.NPCQuestSay, "The Sentinel of the Altar motions for you to enter the altar through the entrance behind him.")
+  end
+end

--- a/kodtaz/Sentinel_of_the_Altar.lua
+++ b/kodtaz/Sentinel_of_the_Altar.lua
@@ -1,8 +1,8 @@
 function event_say(e)
-  local kt_flag = tonumber(e.other:GetAccountbucket("god.flags.kt")) or 0
+  local kt_flag = tonumber(e.other:GetAccountBucket("god.flags.kt")) or 0
   if e.message:findi('hail') then
     if kt_flag <= 32 then
-      e.message(MT.NPCQuestSay, "The Sentinel of the Altar ignores your every attempt to interact with it.")
+      e.other:Message(MT.NPCQuestSay, "The Sentinel of the Altar ignores your every attempt to interact with it.")
     else
       get_expedition(e)
     end
@@ -12,8 +12,13 @@ end
 function event_trade(e)
   local kt_flag = tonumber(e.other:GetAccountBucket("god.flags.kt")) or 0
   local item_lib = require("items")
-  if item_lib.check_turn_in(e.trade, {item1 = 60173}) and kt_flag == 32 then
-    get_expedition(e)
+  if item_lib.check_turn_in(e.trade, {item1 = 60173}) then
+    if kt_flag == 32 then
+      get_expedition(e)
+      e.other:SummonItem(60173)
+    else
+      item_lib.return_items(e.self, e.other, e.trade)
+    end
   end
   
   item_lib.return_items(e.self, e.other, e.trade)
@@ -29,7 +34,7 @@ function get_expedition(e)
   }
   local dz = e.other:CreateExpedition(dz_info)
   if dz.valid then
-    dz.AddReplayLockout(eq.seconds("14h"))
+    dz:AddReplayLockout(eq.seconds("14h"))
     e.other:Message(MT.NPCQuestSay, "The Sentinel of the Altar motions for you to enter the altar through the entrance behind him.")
   end
 end

--- a/kodtaz/Sentinel_of_the_Altar.lua
+++ b/kodtaz/Sentinel_of_the_Altar.lua
@@ -7,6 +7,7 @@ function event_say(e)
       get_expedition(e)
     end
   end
+end
 
 function event_trade(e)
   local kt_flag = tonumber(e.other:GetAccountBucket("god.flags.kt")) or 0

--- a/kodtaz/Tublik_Narwethar.lua
+++ b/kodtaz/Tublik_Narwethar.lua
@@ -1,0 +1,311 @@
+function event_say(e)
+  local kt_flag = tonumber(e.other:GetAccountBucket("god.flags.kt")) or 0
+  local righteous_info = {
+    expedition = { name="Ikkinz, Chambers of Righteousness", min_players=1, max_players=6 },
+    instance = { zone="ikkinz", version=3, duration=eq.seconds("13h") },
+    compass = { zone="kodtaz", x=1340, y=-710, z=-433 },
+    safereturn = { zone="kodtaz", x=1279, y=-2004, z=-349.375, h=336 },
+    zonein = { x=1340, y=710, z=-433, h=256 },
+  }
+  local glorious_info = {
+    expedition = { name="Ikkinz, Chambers of Glorification", min_players=1, max_players=6 },
+    instance = { zone="ikkinz", version=4, duration=eq.seconds("13h") },
+    compass = { zone="kodtaz", x=2656, y=442, z=-396 },
+    safereturn = { zone="kodtaz", x=1279, y=-2004, z=-349.375, h=336 },
+    zonein = { x=2656, y=442, z=-396, h=256 },
+  }
+  local transcend_info = {
+    expedition = { name="Ikkinz, Chambers of Transcendence", min_players=1, max_players=6 },
+    instance = { zone="ikkinz", version=5, duration=eq.seconds("13h") },
+    compass = { zone="kodtaz", x=1573, y=1737, z=-396 },
+    safereturn = { zone="kodtaz", x=1279, y=-2004, z=-349.375, h=336 },
+    zonein = { x=1573, y=1737, z=-396, h=256 },
+  }
+
+  -- Flags below 19, he just grumbles at you
+  if kt_flag < 20 then
+    if e.message:findi("hail") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwether says 'Can I help you with something? Has someone sent you? Speak up!'")
+    end
+  end
+
+  if kt_flag >= 33 then
+    if e.message:findi("hail") then
+      e.other:Message(MT.NPCQuestSay, "Hello again, " .. e.other:GetCleanName() .. "!  You've done great things here in Kod'taz to combat both the Trusik and the Muramites, but I suspect your journey is not yet complete.  If you wish to enter the [" .. eq.say_link("Sanctuary of the Righteous") .. "], the [" .. eq.say_link("Sanctuary of the Glorified") .. "], or the [" .. eq.say_link("Sanctuary of the Transcendent") .. "] again, just say so!")
+    end
+  end
+
+  -- Flag 32: Off you go to the last raid
+  if kt_flag == 32 then
+    if e.message:findi("hail") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'There you are! I've been waiting for you. I've examined the final glyph on the Icon of the Altar and it seems to suggest that there must have been a final battle between the trusik priests and a keeper of some sort. I can't quite determine what the keeper is, but I imagine it won't be friendly. Before you enter the keeper's inner chambers, you'll need to present your Icon of the Altar to a stone [" .. eq.say_link("sentinel") .. "] standing guard outside. By all accounts, this seems to be the same path that the priests had to take as well.'")
+    end
+    if e.message:findi("sentinel") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'Like the keeper, I don't know what you should expect with the sentinel, so be prepared for anything. I must send you on your way now and wish you whatever luck a poor dwarf can muster. Fortune has treated you well so far... let's hope it continues.'")
+    end
+  end
+
+  -- Flag 31: Icon of the Altar
+  if kt_flag == 30 then
+    if e.message:findi("hail") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'Welcome back, " .. e.other:GetCleanName() .. ". It doesn't look like you've been able to finish your Icon of the Altar. Do you remember the [" .. eq.say_link("plan") .. "] I devised to create it? If not, I can explain it to you once more.'")
+    end
+    if e.message:findi("altar of destruction") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'The Altar of Destruction is far more remarkable than any other temple built in this region. I have been catching up on the history of those three artifacts and now you must harness the power that the geomantic priests once held. That power will combine the three pieces you collected into one final [" .. eq.say_link("Icon of the Altar") .. "].'")
+    end
+    if e.message:findi("icon of the altar") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'From what we've seen of the glyphs in the area, we believe the trusik would use their geomantic powers to meld the three pieces together and form the icon. Since we don't have that luxury, we're going to have to do it another way. I've devised a [" .. eq.say_link("plan") .. "] that should replicate what they were trying to do, but it will require more effort on your part.'")
+    end
+    if e.message:findi("plan") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'The first thing you're going to need is something to meld the three pieces together. I believe that using some inanimate ore from the stone guardians that protect the temples will be perfect for this job. The next thing you'll need is to make an inferno scepter to heat up the ore. You'll have to make the scepter yourself, which can be done by combining a flarestone, flaring coals, an inferno scepter mold and a blazing torch in a forge. Hmm. I believe you'll have to head back to the ship to find some of those things. If you don't have the Smithing ability, you should seek out Kaleng on the ship, he may not look like it but he's an expert smith, just ask him for some assistance. In any case, there's one [" .. eq.say_link('final step') .. "] that you need to take before you're done.'")
+    end
+    if e.message:findi("final step") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'Each inferno scepter you make can be used to smelt one block of inanimate ore. Do this three times and you'll get three vials of smelted molten ore. Combine the three vials and the three artifacts in a forge to fuse the three pieces together and hopefully create the Icon of the Altar. When you've finally accomplished all this, show me the icon so I can identify whether this method is one that works or not. Good luck, " .. e.other:GetCleanName() .. ".'")
+      e.other:SetAccountBucket("god.flags.kt", "31")
+    end
+  end
+
+  if kt_flag >= 29 then
+    if e.message:findi("hail") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwether say 'Hello again, " .. e.other:GetCleanName() .. "!  Are you ready to head into the [" .. eq.say_link("sanctuary of the transcendent") .. "]?'")
+    end
+    if e.message:findi("sanctuary of the transcendent") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwether says 'The glyphs you recovered show an Artifact of Transcendence that is guarded by a sentinel that is ages old. You will find the Sanctuary of the Transcendent to the south of the Altar of Destruction. You must gather a raiding party several times larger than your normal party's size and be prepared for anything. Find an entrance to the inner chambers of the Sanctuary of the Transcendent and recover the artifact. May you be gifted with the luck of the brotherhood. I fear you may need it.'")
+      local dz = e.other:CreateExpedition(transcend_info)
+      if dz.valid then
+        dz:AddReplayLockout(eq.seconds("14h"))
+      end
+    end
+  end
+
+  if kt_flag >= 28 then
+    if e.message:findi("hail") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwether say 'Hello again, " .. e.other:GetCleanName() .. "!  Are you ready to head into the [" .. eq.say_link("sanctuary of the glorified") .. "]?'")
+    end
+    if e.message:findi("sanctuary of the glorified") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwether says 'The glyphs you recovered show an Artifact of Glorification that is guarded by a sentinel that is ages old. You will find the Sanctuary of the Glorification to the west of the Altar of Destruction. You must gather a raiding party several times larger than your normal party's size and be prepared for anything. Find an entrance to the inner chambers of the Sanctuary of the Glorified and recover the artifact. May you be gifted with the luck of the brotherhood. I fear you may need it.'")
+      local dz = e.other:CreateExpedition(glorious_info)
+      if dz.valid then
+        dz:AddReplayLockout(eq.seconds("14h"))
+      end
+    end
+  end
+
+  -- Raid 1: Flag 27 and higher
+  if kt_flag >= 27 then
+    if e.message:findi("hail") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwether say 'Hello again, " .. e.other:GetCleanName() .. "!  Are you ready to head into the [" .. eq.say_link("sanctuary of the righteous") .. "]?'")
+    end
+    if e.message:findi("sanctuary of the righteous") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwether says 'The glyphs you recovered show an Artifact of Righteousness that is guarded by a sentinel that is ages old. You will find the Sanctuary of the Righteous to the south of the Altar of Destruction. You must gather a raiding party several times larger than your normal party's size and be prepared for anything. Find an entrance to the inner chambers of the Sanctuary of the Righteous and recover the artifact. May you be gifted with the luck of the brotherhood. I fear you may need it.'")
+      local dz = e.other:CreateExpedition(righteous_info)
+      if dz.valid then
+        dz:AddReplayLockout(eq.seconds("14h"))
+      end
+    end
+  end
+
+  -- Flag 27: Ikk Raid 1
+  if kt_flag == 27 then
+    if e.message:findi("hail") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'I wasn't expecting you back so soon, " .. e.other:GetCleanName() .. ", but I'm glad you're here. I've been analyzing the glyphs on the last three artifacts you recovered and, the way I read them, it seems the trusik priests used the [" .. eq.say_link("four temples") .. "] around the Altar of Destruction to gain access to a temple to face some kind of final rite of passage.'")
+    end
+    if e.message:findi("four temples") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'As you've already uncovered, the Sanctuary of Divine Destruction was used to uncover the purpose for the other three. I believe the Muramites destroyed that temple because it holds the key to the remaining three temples and the artifacts that they hold. Now that we know what's ahead, we can continue forth and unravel this [" .. eq.say_link("mystery") .. "].'")
+    end
+    if e.message:findi("mystery") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'It's clear to me that you must proceed into each of the three remaining temples and recover the three artifacts that are in them. You should start with the [" .. eq.say_link("sanctuary of the righteous") .. "'") 
+    end
+  end
+
+  -- Flag 26: Additional Clues
+  if kt_flag == 26 then
+    if e.message:findi("hail") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'Welcome back, " .. e.other:GetCleanName() .. ".  Have you been able to find [" .. eq.say_link("more clues") .. "?'")
+    end
+    if e.message:findi("ritual") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'I've been assuming that only the Muramites were so cruel that they would rip flesh from another living being in this manner, but it appears that the trusik priests were the ones that did it. They etched glyphs into the skin and then removed it to be used later. The glyphs represent the four temples and their direct connection to the Altar of Destruction. It looks as though there may be [" .. eq.say_link("more clues") .. "] about the Altar of Destruction and its surrounding temples in the trial temples.'")
+    end
+    if e.message:findi("more clues") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'I need you to return to the three temples where you participated in the three trials. Based on this clue, I believe you will find three additional clues about the Altar of Destruction in the Temple of Singular Might, the Temple of Twin Struggles, and the Temple of the Tri-Fates. I doubt they'll be hard to find, but you must go to each and search for the clues! Return to me when you have found them!'")
+    end
+  end
+
+  -- Flag 25: Making the Sewn Flesh Parchment
+  if kt_flag == 25 then
+    if e.message:findi("hail") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'Welcome back, " .. e.other:GetCleanName() .. ".  Have you made any progress with the runes [" .. eq.say_link("made of flesh") .. "]?'")
+    end
+    if e.message:findi("made of flesh") then
+      e.other:Message(MT.NPCQuestSay, "Tublik shakes his head. 'I know it's not very pleasant, but you've got to remember that these Muramites are a new type of scum like nothing else we've ever come across. I think we can salvage some information from this, but it will require you to venture back into areas infested with Muramites. You'll need to [" .. eq.say_link("gather some materials") .. "] for me so we can sew the flesh back together.'")
+    end
+    if e.message:findi("gather some materials") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'The first thing you'll need is a needle. We can't take any chances with the use of Muramite-altered flesh so you'll need to make your own. To do so, you'll need to find four bone chips and combine them with some of the weird black residue that the Muramites leave behind when they die. You should be able to fashion them together with a sewing kit. The next thing you'll need to do is get some [" .. eq.say_link("strands of hair") .. "] to keep the flesh together.'")
+    end
+    if e.message:findi("strands of hair") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'You'll need to gather four strands of hair from the local hynids. They're not friendly, so be careful when you encounter one. Once you've gotten the strands and made your needle, you're going to need to sew the strands together using the needle. It seems strange I know, but remember that the best solutions are usually the simplest ones. Take the hynid thread and the needle and your four pieces of flesh and sew them together. That should get you what you need. Once you've sewn the clue back together, give it to me, and I may finally be able to understand it.'  He pauses for a moment.  'By the way, if you happen to not know your way around a needle, these materials will be very difficult to use.  I'd suggest heading back to the ship and asking Adsame Leing for some tailoring assistance.")
+    end
+  end
+
+  -- Flag 24: Asking about Crumbled Sanctuary
+  if kt_flag == 23 then
+    if e.message:findi("hail") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'Nice to see you again, " .. e.other:GetCleanName() .. ". This whole time we've been looking at the artifacts that the Muramites have been collecting, but we've been [" .. eq.say_link('ignoring something') .. "] and I think it's time we looked into it.'")
+    end
+    if e.message:findi("ignoring something") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'Perhaps you've heard of the Altar of Destruction? It is the largest, most visible temple just to the north of here. You can't miss it. If you were to venture just east of it, you would come across a temple that appears destroyed. This temple is called the [" .. eq.say_link("Crumbled Sanctuary") .. "] of Divine Destruction according to the historical information we've received. I have yet to uncover what its purpose is.'")
+    end
+    if e.message:findi("crumbled sanctuary") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'Oh yeah, I know all about that thing. It was a temple that was decimated by the Muramites during their initial invasion. We're unsure what caused them to destroy that temple, but not the other three. I need you to go to the temple and [" .. eq.say_link("look for clues") .. "] as to what the reason may have been for destroying the temple.'")
+    end
+    if e.message:findi("look for clues") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'I have no idea what the clues may look like, but I'm hoping they'll bring about some insight as to the reason behind the Muramites destroying the temple. Once you've recovered all the clues you can find, please come back to me so I can go over them. If we're lucky, I'll be able to decipher what the real cause was and we can relay that important news to the brotherhood. Off you go, " .. e.other:GetCleanName() .. ", and good luck!'")
+      e.other:SetAccountBucket("god.flags.kt", "24")
+    end
+  end
+
+  -- Flag 22: Asking about the Ageless Relic Protector (this will still work after you talked to him, in case they need to spawn the Ageless Relic Protector again)
+  if kt_flag == 21 or kt_flag == 22 then
+    if e.message:findi("hail") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'Welcome back, " .. e.other:GetCleanName() .. ". I've been looking over those artifacts you returned to me in the sealed bag and I'm afraid I have some disturbing news. It seems the artifacts weren't artifacts at all, but objects of ghastly power held by the dark spirits you collected them from. What's worse is that since you've collected these objects, the energy emanating from the pit has [" .. eq.say_link("gotten stronger") .. "]!'")
+    end
+    if e.message:findi("gotten stronger") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'The power wasn't as noticeable before. Now, though, it seems there's a fiend in the pit that's become agitated by the removal of these objects we've been collecting. I believe that whatever is behind the energy disruption kept a watchful eye over those objects. Now that they're gone, I believe it will try to find them again and destroy anything and everything in its path in the process. You must [" .. eq.say_link("stop it") .. "] before it has a chance!'")
+    end
+    if e.message:findi("stop it") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'You must return to the Pit of the Lost and find whatever this fiend is and destroy it. I believe that it will have some kind of artifact that is linked to the ones you returned to me in the sealed bag. Return whatever it may have to me. Good luck, " .. e.other:GetCleanName() .. ", I have no doubt that the artifact it holds will be as interesting of a find as anything else we've uncovered so far!'")
+      e.other:SetAccountBucket("god.flags.kt", "22")
+      local npcs = eq.get_entity_list()
+      local arp = npcs:GetNPCByNPCTypeID(293221)
+      if not arp.valid then --Don't spawn the Ageless Relic Protector if one is already available.
+        eq.spawn2(293221, 0, 0, 2176, 2184, -476, 274)
+      end 
+    end
+  end
+
+  -- Flag 20: Asking about the Pit of the Lost
+  if kt_flag == 19 then
+    if e.message:findi("hail") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar glances at you suspiciously. 'Can I help you with something? Did Kevren send you about the [" .. eq.say_link("Pit of the Lost") .. "]? Speak up!'")
+    end
+    if e.message:findi("pit of the lost") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'I see Kevren finally sent someone to me to look into the pit. It's about time! I've been telling him over and over that there are some really strange things going on in the Pit of the Lost to the north of here, but he just doesn't seem to want to pay enough attention to the claims. In any case, you're here now and that means that you must be [" .. eq.say_link("willing to look") .. "] into the odd occurrences, right?'")
+    end
+    if e.message:findi("willing to look") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'I'm glad I can count on you. You need to know a couple things before you go. As I said, there are strange things going on in the pit, but we're not sure what they are yet. We have sensed an energy force emanating from that area and believe there are some kind of artifacts there that must be collected. We need you to [" .. eq.say_link("collect the artifacts") .. "] and return them so we can study them.'")
+    end
+    if e.message:findi("collect the artifacts") then
+      e.other:Message(MT.NPCQuestSay, "Tublik hands you a bag and says, 'Place four artifacts you find from the pit in this bag and seal it off. Return the sealed bag to me when you're done so I can further examine what you find. Make haste to the Pit of the Lost and be careful -- there's no telling what kind of evils are waiting for you there. If you have someone else with you that [" .. eq.say_link("needs a bag") .. "], have them tell me so.'")
+      e.other:SummonItem(60155)
+      e.other:SetAccountBucket("eq.flags.god", "20")
+    end
+    if e.message:findi("needs a bag") then
+      e.other:Message(MT.NPCQuestSay, "Tublik nods gruffly and hands you one of his bags.")
+      e.other:SummonItem(60155)
+      e.other:SetAccountBucket("eq.flags.god", "20")
+    end
+  end
+
+  -- Flag 15: Asking about the stone tablet
+  if kt_flag == 15 then
+    if e.message:findi("stone tablet") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'You need a stone tablet? What for? What have you got that's so special it requires the use of a stone tablet?'")
+    end
+    if e.message:findi("glyph of the damned") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'Ahh, you're looking to translate some glyphs, eh? You're in luck then, " .. e.other:GetCleanName() .. ". I just happen to have a stone tablet available for you to use. I need to make sure you actually need it before I hand one out to you. Wouldn't want these getting into the wrong hands, you know. Show me one of the glyphs you need to translate and if I am satisfied with what I see, I'll let you have one.'")
+    end
+  end
+end
+
+
+function event_trade(e)
+  local kt_flag = tonumber(e.other:GetAccountBucket("god.flags.kt")) or 0
+  local item_lib = require("items")
+
+  if item_lib.check_turn_in(e.trade, {item1 = 60146}) and kt_flag == 15 then
+    e.other:SummonItem(60146)
+    give_tablet(e, kt_flag)
+  end
+  if item_lib.check_turn_in(e.trade, {item1 = 60147}) and kt_flag == 15 then
+    e.other:SummonItem(60147)
+    give_tablet(e, kt_flag)
+  end
+  if item_lib.check_turn_in(e.trade, {item1 = 60148}) and kt_flag == 15 then
+    e.other:SummonItem(60148)
+    give_tablet(e, kt_flag)
+  end
+  if item_lib.check_turn_in(e.trade, {item1 = 60148}) and kt_flag == 15 then
+    e.other:SummonItem(60148)
+    give_tablet(e, kt_flag)
+  end
+
+  if item_lib.check_turn_in(e.trade, {item1 = 60156, item2 = 60157, item3 = 60158, item4 = 60159}) and kt_flag == 20 then
+    e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'You're done already? I wasn't expecting such a prompt response, but nicely done " .. e.other:GetCleanName() .. "! Give me a while to examine these artifacts. I should have some additional information for you once you return.'")
+    e.other:SetAccountBucket("god.flags.kt", "21")
+  end
+
+  if item_lib.check_turn_in(e.trade, {item1 = 60161}) and kt_flag == 22 then
+    e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'Excellent! We don't have to worry about that abomination any longer. This artifact you found on the creature is also quite unique. It will be a while before I have a chance to look it over, but it's nice to have it in our possession nonetheless. Well done once again, " .. e.other:GetCleanName() .. ". I look forward to working with you again soon!'")
+    e.other:SetAccountBucket("god.flags.kt", "23")
+  end
+
+  if item_lib.check_turn_in(e.trade, {item1 = 60162, item2 = 60163, item3 = 60164, item4 = 60165}) and kt_flag == 24 then
+    e.other:Message(MT.NPCQuestSay, "Tublik grunts unhappily at the four pieces. 'I had hoped more work wouldn't be needed to uncover the clues, but it looks like there's a bit more you're going to need to do for me. Take a look at these edges. Do you see how they look really sinewy? That's because they're [" .. eq.say_link("made of flesh") .. "], probably that of the trusik. No doubt the Muramites have been quite cruel to them now that they are mostly used for slavery.'")
+    e.other:SummonItem(60162)
+    e.other:SummonItem(60163)
+    e.other:SummonItem(60164)
+    e.other:SummonItem(60165)
+    e.other:SetAccountBucket("god.flags.kt", "25")
+  end
+
+  if item_lib.check_turn_in(e.trade, {item1 = 60166}) and kt_flag == 25 then 
+    e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'Nicely sewn, " .. e.other:GetCleanName() .. ". I would have tried doing it myself, but I have the most unsteady fingers when it comes to things like that. In any case, let me have a look at what this says.' Tublik looks over the clue for a time before continuing. 'Unbelievable. Simply astounding. These notes weren't made by the Muramites at all. In fact, they were created by trusik priests from their own flesh in some kind of [" .. eq.say_link("ritual") .. "].'")
+    e.other:SetAccountBucket("god.flags.kt", "26")
+  end
+
+  if item_lib.check_turn_in(e.trade, {item1 = 60167, item2 = 60168, item3 = 60169}) and kt_flag == 26 then
+    e.other:Message(MT.NPCQuestSay, "Tublik stares at the three clues for a moment before speaking. 'I can't be sure, but I believe we are getting close to something big, " .. e.other:GetCleanName() .. ". I need more time to examine these clues, but I should have something for you when you return. You've done well and I know that we wouldn't have been able to get this far without your help. Good job!'")
+    e.other:SetAccountBucket("god.flags.kt", "27")
+  end
+
+  if item_lib.check_turn_in(e.trade, {item = 60170}) and kt_flag == 27 then
+    e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'You've done it! You've recovered the first of the three artifacts! You must keep this with you, as you'll need it once you've recovered all three artifacts. The next temple is the[" .. eq.say_link("Sanctuary of the Glorified") .. "], are you ready".. e.other:GetCleanName() .. "?")
+    e.other:Message(MT.LightBlue, "Finished! - You've recovered the Artifact of Righteousness!")
+    e.other:SummonItem(60170)
+    e.other:SetAccountBucket("god.flags.kt", "28")
+  end
+
+  if item_lib.check_turn_in(e.trade, {item = 60171}) and kt_flag == 28 then
+    e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'You've done it! You've recovered the second of the three artifacts! You must keep this with you, because you'll need it once you've recovered all three artifacts. You only need one more from the [" .. eq.say_link("Sanctuary of the Transcendent") .. "]. Are you ready to progress forward with the final artifact?'")
+    e.other:Message(MT.LightBlue, "Finished! - You've recovered the Artifact of Glorification!")
+    e.other:SummonItem(60171)
+    e.other:SetAccountBucket("god.flags.kt", "29")
+  end
+
+  if item_lib.check_turn_in(e.trade, {item = 60172}) and kt_flag == 29 then
+    e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'You've done it! You've recovered all three of the artifacts! You must keep this with you, because you'll need it now. Somewhere deep down I knew you would be able to get them all. I've been studying the markings from the artifacts and I've come to the conclusion that they must be combined to form a key to enter the [" .. eq.say_link("Altar of Destruction") .. "].'")
+    e.other:Message(MT.LightBlue, "Finished! - You've recovered the Artifact of Transcendence!")
+    e.other:SummonItem(60172)
+    e.other:SetAccountBucket("god.flags.kt", "30")
+  end
+
+  if item_lib.check_turn_in(e.trade, {item = 60173}) and kt_flag == 31 then
+    e.other:Message(MT.NPCQuestSay, "Tublik scans the icon before returning it to you. 'You've done well, " .. e.other:GetCleanName() .. ". Up until now I hadn't noticed the final glyph that is created when the three pieces are combined. I must inspect this further, but return to me shortly and I should have an answer as to the glyph's meaning.'")
+    e.other:SummonItem(60172)
+    e.other:SetAccountBucket("god.flags.kt", "32")
+  end
+
+  if item_lib.check_turn_in(e.trade, {item = 60174}) and kt_flag == 32 then
+    e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'You've exceed all my expectations. This key is only the first of what looks to be three needed... needed for what I wonder? I imagine you'll find out more as you continue your adventures. Seek out Brevik in the Abysmal Sea should you discover anything else. He is one of the Wayfarers Brotherhood's resident geomancer adepts. He's not yet fully skilled, but he has much in the way of knowledge of the craft already and learning more each day. He will no doubt have more information for you. For now, I bid you good luck and farewell, " .. e.other:GetCleanName() .. "!'")
+    e.other:SummonItem(60176)
+    e.other:SetAccountBucket("god.flags.kt", "33")
+  end
+end
+
+function give_tablet(e, kt_flag)
+  e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'So, you really are helping Kevren with this. My apologies for being so blunt with the requirements, but you never can be too careful with things like this. Here's a stone tablet for your troubles. You're going to need to use as many piles of dust as you have glyphs, then combine the dust and the four glyphs together with the stone tablet to translate them. These glyphs can be tricky, so good luck.'")
+  e.other:SummonItem(60175) 
+  if kt_flag == 15 then
+    e.other:SetAccountBucket("god.flags.kt", "16")
+  end
+end

--- a/kodtaz/Tublik_Narwethar.lua
+++ b/kodtaz/Tublik_Narwethar.lua
@@ -22,8 +22,10 @@ function event_say(e)
     zonein = { x=1573, y=1737, z=-396, h=256 },
   }
 
+
+
   -- Flags below 19, he just grumbles at you
-  if kt_flag < 20 then
+  if kt_flag < 19 then
     if e.message:findi("hail") then
       e.other:Message(MT.NPCQuestSay, "Tublik Narwether says 'Can I help you with something? Has someone sent you? Speak up!'")
     end
@@ -31,7 +33,7 @@ function event_say(e)
 
   if kt_flag >= 33 then
     if e.message:findi("hail") then
-      e.other:Message(MT.NPCQuestSay, "Hello again, " .. e.other:GetCleanName() .. "!  You've done great things here in Kod'taz to combat both the Trusik and the Muramites, but I suspect your journey is not yet complete.  If you wish to enter the [" .. eq.say_link("Sanctuary of the Righteous") .. "], the [" .. eq.say_link("Sanctuary of the Glorified") .. "], or the [" .. eq.say_link("Sanctuary of the Transcendent") .. "] again, just say so!")
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwether says 'Hello again, " .. e.other:GetCleanName() .. "!  You've done great things here in Kod'taz to combat both the Trusik and the Muramites, but I suspect your journey is not yet complete.  If you wish to enter the [" .. eq.say_link("Sanctuary of the Righteous") .. "], the [" .. eq.say_link("Sanctuary of the Glorified") .. "], or the [" .. eq.say_link("Sanctuary of the Transcendent") .. "] again, just say so!'")
     end
   end
 
@@ -42,6 +44,12 @@ function event_say(e)
     end
     if e.message:findi("sentinel") then
       e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'Like the keeper, I don't know what you should expect with the sentinel, so be prepared for anything. I must send you on your way now and wish you whatever luck a poor dwarf can muster. Fortune has treated you well so far... let's hope it continues.'")
+    end
+  end
+
+  if kt_flag == 31 then
+    if e.message:findi("hail") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'Welcome back, " .. e.other:GetCleanName() .. ". Any luck with creating the Icon of the Altar?'")
     end
   end
 
@@ -65,10 +73,13 @@ function event_say(e)
     end
   end
 
-  if kt_flag >= 29 then
+  if kt_flag == 29 then
     if e.message:findi("hail") then
       e.other:Message(MT.NPCQuestSay, "Tublik Narwether say 'Hello again, " .. e.other:GetCleanName() .. "!  Are you ready to head into the [" .. eq.say_link("sanctuary of the transcendent") .. "]?'")
     end
+  end
+
+  if kt_flag >= 29 then
     if e.message:findi("sanctuary of the transcendent") then
       e.other:Message(MT.NPCQuestSay, "Tublik Narwether says 'The glyphs you recovered show an Artifact of Transcendence that is guarded by a sentinel that is ages old. You will find the Sanctuary of the Transcendent to the south of the Altar of Destruction. You must gather a raiding party several times larger than your normal party's size and be prepared for anything. Find an entrance to the inner chambers of the Sanctuary of the Transcendent and recover the artifact. May you be gifted with the luck of the brotherhood. I fear you may need it.'")
       local dz = e.other:CreateExpedition(transcend_info)
@@ -78,27 +89,16 @@ function event_say(e)
     end
   end
 
-  if kt_flag >= 28 then
+  if kt_flag == 28 then
     if e.message:findi("hail") then
       e.other:Message(MT.NPCQuestSay, "Tublik Narwether say 'Hello again, " .. e.other:GetCleanName() .. "!  Are you ready to head into the [" .. eq.say_link("sanctuary of the glorified") .. "]?'")
     end
+  end
+
+  if kt_flag >= 28 then
     if e.message:findi("sanctuary of the glorified") then
       e.other:Message(MT.NPCQuestSay, "Tublik Narwether says 'The glyphs you recovered show an Artifact of Glorification that is guarded by a sentinel that is ages old. You will find the Sanctuary of the Glorification to the west of the Altar of Destruction. You must gather a raiding party several times larger than your normal party's size and be prepared for anything. Find an entrance to the inner chambers of the Sanctuary of the Glorified and recover the artifact. May you be gifted with the luck of the brotherhood. I fear you may need it.'")
       local dz = e.other:CreateExpedition(glorious_info)
-      if dz.valid then
-        dz:AddReplayLockout(eq.seconds("14h"))
-      end
-    end
-  end
-
-  -- Raid 1: Flag 27 and higher
-  if kt_flag >= 27 then
-    if e.message:findi("hail") then
-      e.other:Message(MT.NPCQuestSay, "Tublik Narwether say 'Hello again, " .. e.other:GetCleanName() .. "!  Are you ready to head into the [" .. eq.say_link("sanctuary of the righteous") .. "]?'")
-    end
-    if e.message:findi("sanctuary of the righteous") then
-      e.other:Message(MT.NPCQuestSay, "Tublik Narwether says 'The glyphs you recovered show an Artifact of Righteousness that is guarded by a sentinel that is ages old. You will find the Sanctuary of the Righteous to the south of the Altar of Destruction. You must gather a raiding party several times larger than your normal party's size and be prepared for anything. Find an entrance to the inner chambers of the Sanctuary of the Righteous and recover the artifact. May you be gifted with the luck of the brotherhood. I fear you may need it.'")
-      local dz = e.other:CreateExpedition(righteous_info)
       if dz.valid then
         dz:AddReplayLockout(eq.seconds("14h"))
       end
@@ -114,14 +114,24 @@ function event_say(e)
       e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'As you've already uncovered, the Sanctuary of Divine Destruction was used to uncover the purpose for the other three. I believe the Muramites destroyed that temple because it holds the key to the remaining three temples and the artifacts that they hold. Now that we know what's ahead, we can continue forth and unravel this [" .. eq.say_link("mystery") .. "].'")
     end
     if e.message:findi("mystery") then
-      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'It's clear to me that you must proceed into each of the three remaining temples and recover the three artifacts that are in them. You should start with the [" .. eq.say_link("sanctuary of the righteous") .. "'") 
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'It's clear to me that you must proceed into each of the three remaining temples and recover the three artifacts that are in them. You should start with the [" .. eq.say_link("sanctuary of the righteous") .. "]'") 
+    end
+  end
+
+  if kt_flag >= 27 then
+    if e.message:findi("sanctuary of the righteous") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwether says 'The glyphs you recovered show an Artifact of Righteousness that is guarded by a sentinel that is ages old. You will find the Sanctuary of the Righteous to the south of the Altar of Destruction. You must gather a raiding party several times larger than your normal party's size and be prepared for anything. Find an entrance to the inner chambers of the Sanctuary of the Righteous and recover the artifact. May you be gifted with the luck of the brotherhood. I fear you may need it.'")
+      local dz = e.other:CreateExpedition(righteous_info)
+      if dz.valid then
+        dz:AddReplayLockout(eq.seconds("14h"))
+      end
     end
   end
 
   -- Flag 26: Additional Clues
   if kt_flag == 26 then
     if e.message:findi("hail") then
-      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'Welcome back, " .. e.other:GetCleanName() .. ".  Have you been able to find [" .. eq.say_link("more clues") .. "?'")
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'Welcome back, " .. e.other:GetCleanName() .. ".  Have you been able to find [" .. eq.say_link("more clues") .. "]?'")
     end
     if e.message:findi("ritual") then
       e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'I've been assuming that only the Muramites were so cruel that they would rip flesh from another living being in this manner, but it appears that the trusik priests were the ones that did it. They etched glyphs into the skin and then removed it to be used later. The glyphs represent the four temples and their direct connection to the Altar of Destruction. It looks as though there may be [" .. eq.say_link("more clues") .. "] about the Altar of Destruction and its surrounding temples in the trial temples.'")
@@ -144,6 +154,12 @@ function event_say(e)
     end
     if e.message:findi("strands of hair") then
       e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'You'll need to gather four strands of hair from the local hynids. They're not friendly, so be careful when you encounter one. Once you've gotten the strands and made your needle, you're going to need to sew the strands together using the needle. It seems strange I know, but remember that the best solutions are usually the simplest ones. Take the hynid thread and the needle and your four pieces of flesh and sew them together. That should get you what you need. Once you've sewn the clue back together, give it to me, and I may finally be able to understand it.'  He pauses for a moment.  'By the way, if you happen to not know your way around a needle, these materials will be very difficult to use.  I'd suggest heading back to the ship and asking Adsame Leing for some tailoring assistance.")
+    end
+  end
+
+  if kt_flag == 24 then
+    if e.message:findi("hail") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'Welcome back, " .. e.other:GetCleanName() .. ". Have you recovered anything from the Crumbled Sanctuary?'")
     end
   end
 
@@ -183,6 +199,12 @@ function event_say(e)
     end
   end
 
+  if kt_flag == 20 then
+    if e.message:findi("hail") then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'Welcome back, " .. e.other:GetCleanName() .. ". Have you recovered anything from the Pit of the Lost?'")
+    end
+  end
+
   -- Flag 20: Asking about the Pit of the Lost
   if kt_flag == 19 then
     if e.message:findi("hail") then
@@ -197,12 +219,12 @@ function event_say(e)
     if e.message:findi("collect the artifacts") then
       e.other:Message(MT.NPCQuestSay, "Tublik hands you a bag and says, 'Place four artifacts you find from the pit in this bag and seal it off. Return the sealed bag to me when you're done so I can further examine what you find. Make haste to the Pit of the Lost and be careful -- there's no telling what kind of evils are waiting for you there. If you have someone else with you that [" .. eq.say_link("needs a bag") .. "], have them tell me so.'")
       e.other:SummonItem(60155)
-      e.other:SetAccountBucket("eq.flags.god", "20")
+      e.other:SetAccountBucket("god.flags.kt", "20")
     end
     if e.message:findi("needs a bag") then
       e.other:Message(MT.NPCQuestSay, "Tublik nods gruffly and hands you one of his bags.")
       e.other:SummonItem(60155)
-      e.other:SetAccountBucket("eq.flags.god", "20")
+      e.other:SetAccountBucket("god.flags.kt", "20")
     end
   end
 
@@ -213,6 +235,111 @@ function event_say(e)
     end
     if e.message:findi("glyph of the damned") then
       e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'Ahh, you're looking to translate some glyphs, eh? You're in luck then, " .. e.other:GetCleanName() .. ". I just happen to have a stone tablet available for you to use. I need to make sure you actually need it before I hand one out to you. Wouldn't want these getting into the wrong hands, you know. Show me one of the glyphs you need to translate and if I am satisfied with what I see, I'll let you have one.'")
+    end
+  end
+
+  --Flags 2 and up: Progress Report
+  if kt_flag >= 2 then
+    if e.message:findi("hail") then
+      e.other:Message(MT.Yellow, "Tublik Narwethar says 'If you want to see what you've completed at any time, just ask me for a [" .. eq.say_link("progress update") .. "]!'")
+    end
+    if e.message:findi("progress update") then
+      if kt_flag >= 10 then
+        e.other:Message(MT.Yellow, "Finished! - You can now retry any of the trials at any time!")
+      end
+      if kt_flag == 2 or kt_flag == 3 then
+        e.other:Message(MT.Yellow, "Pending - You have been commissioned by Kevran Nalavat to undertake the Trial of Singular Might.")
+      elseif kt_flag >= 4 then
+        e.other:Message(MT.Yellow, "Finished! - You have completed the trial at the Temple of Singular Might!")
+      end
+      if kt_flag == 5 or kt_flag == 6 then
+        e.other:Message(MT.Yellow, "Pending - You have been commissioned by Kevran Nalavat to undertake the Trial of Twin Struggles.")
+      elseif kt_flag >= 7 then
+        e.other:Message(MT.Yellow, "Finished! - You have completed the trial at the Temple of Twin Struggles!")
+      end
+      if kt_flag == 8 or kt_flag == 9 then
+        e.other:Message(MT.Yellow, "Pending - You have been commissioned by Kevran Nalavat to undertake the Trial of Tri-Fates")
+      elseif kt_flag >= 10 then
+        e.other:Message(MT.Yellow, "Finished! - You have completed the trial at the Temple of Tri-Fates!")
+      end
+      if kt_flag == 11 then
+        e.other:Message(MT.Yellow, "Pending - You have been commissioned by Kevran Nalavat to investigate the Martyrs Passage.")
+      end
+      if kt_flag >= 12 then
+        e.other:Message(MT.Yellow, "Finished! - You returned four relics from the Martyrs Passage!")
+      end
+      if kt_flag == 12 then
+        e.other:Message(MT.Yellow, "Pending - You haven't yet returned any information as to why the Muramites are in Martyrs Passage.")
+      end
+      if kt_flag >= 13 then
+        e.other:Message(MT.Yellow, "Finished! - You returned valuable information as to why the Muramites are in the Martyrs Passage!")
+      end
+      if kt_flag >= 14 then
+        e.other:Message(MT.Yellow, "Finished! - You've been comissioned to investigate the Temple of the Damned.")
+      end
+      if kt_flag >= 15 then
+        e.other:Message(MT.Yellow, "Finished! - You've recovered important glyphs from the Temple of the Damned!")
+      end
+      if kt_flag == 15 or kt_flag == 16 then
+        e.other:Message(MT.Yellow, "Pending - You haven't translated the glyphs gathered from the Temple of the Damned.")
+      end
+      if kt_flag >= 17 then
+        e.other:Message(MT.Yellow, "Finished! - You've successfully translated the glyphs you found in the Temple of the Damned!")
+      end
+      if kt_flag >= 18 then
+        e.other:Message(MT.Yellow, "Finished! - You've been charged with stopping the ceremony at the Summoning Circle!")
+      end
+      if kt_flag >= 19 then
+        e.other:Message(MT.Yellow, "Finished! - You were able to recover a rare artifact from the Grand Summoner's goons in the Summoning Circle!")
+      end
+      if kt_flag == 20 then
+	e.other:Message(MT.Yellow, "Pending - You've been tasked by Tublik Narwether to investigate the Pit of the Lost and recover relics.")
+      end
+      if kt_flag >= 21 then
+	e.other:Message(MT.Yellow, "Finished! - You've collected the Minor Relics of Power from the Pit of the Lost!")
+      end
+      if kt_flag == 22 then
+	e.other:Message(MT.Yellow, "Pending - You;ve been tasked by Tublik Narwether to investigate a disturbance at the Pit of the Lost.")
+      end
+      if kt_flag >= 23 then
+	e.other:Message(MT.Yellow, "Finished! - You've rescued the artifact from the Ageless Relic Protector in the Pit of the Lost!")
+      end
+      if kt_flag >= 24 then
+        e.other:Message(MT.Yellow, "Finished! - You've been sent to gather any clues you can find from the Crumbled Sanctuary of Divine Destruction!")
+      end
+      if kt_flag >= 25 then
+        e.other:Message(MT.Yellow, "Finished! - You have collected the four Frayed Flesh Scraps from the Crumbled Sanctuary of Divine Destruction!")
+      end
+      if kt_flag >= 26 then
+        e.other:Message(MT.Yellow, "Finished! - You've sewn the flesh scraps together to make the Sewn Flesh Parchment!")
+      end
+      if kt_flag >= 27 then
+        e.other:Message(MT.Yellow, "Finished! - You've found the three clues from the three trial temples!")
+      end
+      if kt_flag >= 28 then
+        e.other:Message(MT.Yellow, "Finished! - You've recovered the Artifact of Righteousness!")
+      end
+      if kt_flag >= 29 then
+        e.other:Message(MT.Yellow, "Finished! - You've recovered the Artifact of Glorification!")
+      end
+      if kt_flag >= 30 then
+        e.other:Message(MT.Yellow, "Finished! - You've recovered the Artifact of Transcendence!")
+      end
+      if kt_flag >= 31 then
+        e.other:Message(MT.Yellow, "Finished! - You've been instructed on what needs to be done to make the Icon of the Altar!")
+      end
+      if kt_flag >= 32 then
+        e.other:Message(MT.Yellow, "Finished! - You've constructed your Icon of the Altar!")
+      end
+      if kt_flag >= 33 then
+        e.other:Message(MT.Yellow, "You have obtained a Sliver of the High Temple!  Congratulations!")
+      end
+      if kt_flag == 34 then
+        e.other:Message(MT.Yellow, "The barrier to Qvic has been breeched by your possession of the Sliver of the High Temple and the Fragment of the High Temple!")
+      end
+      if kt_flag < 33 then
+        e.other:Message(MT.Yellow, "Kod'taz still has secrets to discover...")
+      end
     end
   end
 end
@@ -227,7 +354,7 @@ function event_trade(e)
     if kt_flag == 15 then
       give_tablet(e, kt_flag)
     else
-      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'I've already seen this glyph, you should use the stone tablet to translate it.'")
+      item_lib.return_items(e.self, e.other, e.trade)
     end
   end
 
@@ -236,7 +363,7 @@ function event_trade(e)
     if kt_flag == 15 then
       give_tablet(e, kt_flag)
     else
-      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'I've already seen this glyph, you should use the stone tablet to translate it.'")
+      item_lib.return_items(e.self, e.other, e.trade)
     end
   end
   if item_lib.check_turn_in(e.trade, {item1 = 60148}) then
@@ -244,7 +371,7 @@ function event_trade(e)
     if kt_flag == 15 then
       give_tablet(e, kt_flag)
     else
-      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'I've already seen this glyph, you should use the stone tablet to translate it.'")
+      item_lib.return_items(e.self, e.other, e.trade)
     end
   end
   if item_lib.check_turn_in(e.trade, {item1 = 60149}) then
@@ -252,70 +379,110 @@ function event_trade(e)
     if kt_flag == 15 then
       give_tablet(e, kt_flag)
     else
-      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'I've already seen this glyph, you should use the stone tablet to translate it.'")
+      item_lib.return_items(e.self, e.other, e.trade)
     end
   end
 
-  if item_lib.check_turn_in(e.trade, {item1 = 60156, item2 = 60157, item3 = 60158, item4 = 60159}) and kt_flag == 20 then
-    e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'You're done already? I wasn't expecting such a prompt response, but nicely done " .. e.other:GetCleanName() .. "! Give me a while to examine these artifacts. I should have some additional information for you once you return.'")
-    e.other:SetAccountBucket("god.flags.kt", "21")
+  if item_lib.check_turn_in(e.trade, {item1 = 60160}) then
+    if kt_flag == 20 then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'You're done already? I wasn't expecting such a prompt response, but nicely done " .. e.other:GetCleanName() .. "! Give me a while to examine these artifacts. I should have some additional information for you once you return.'")
+      e.other:SetAccountBucket("god.flags.kt", "21")
+    else
+      item_lib.return_items(e.self, e.other, e.trade)
+    end
   end
 
-  if item_lib.check_turn_in(e.trade, {item1 = 60161}) and kt_flag == 22 then
-    e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'Excellent! We don't have to worry about that abomination any longer. This artifact you found on the creature is also quite unique. It will be a while before I have a chance to look it over, but it's nice to have it in our possession nonetheless. Well done once again, " .. e.other:GetCleanName() .. ". I look forward to working with you again soon!'")
-    e.other:SetAccountBucket("god.flags.kt", "23")
+  if item_lib.check_turn_in(e.trade, {item1 = 60161}) then
+    if kt_flag == 22 then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'Excellent! We don't have to worry about that abomination any longer. This artifact you found on the creature is also quite unique. It will be a while before I have a chance to look it over, but it's nice to have it in our possession nonetheless. Well done once again, " .. e.other:GetCleanName() .. ". I look forward to working with you again soon!'")
+      e.other:SetAccountBucket("god.flags.kt", "23")
+    else
+      item_lib.return_items(e.self, e.other, e.trade)
+    end
   end
 
-  if item_lib.check_turn_in(e.trade, {item1 = 60162, item2 = 60163, item3 = 60164, item4 = 60165}) and kt_flag == 24 then
-    e.other:Message(MT.NPCQuestSay, "Tublik grunts unhappily at the four pieces. 'I had hoped more work wouldn't be needed to uncover the clues, but it looks like there's a bit more you're going to need to do for me. Take a look at these edges. Do you see how they look really sinewy? That's because they're [" .. eq.say_link("made of flesh") .. "], probably that of the trusik. No doubt the Muramites have been quite cruel to them now that they are mostly used for slavery.'")
-    e.other:SummonItem(60162)
-    e.other:SummonItem(60163)
-    e.other:SummonItem(60164)
-    e.other:SummonItem(60165)
-    e.other:SetAccountBucket("god.flags.kt", "25")
+  if item_lib.check_turn_in(e.trade, {item1 = 60162, item2 = 60163, item3 = 60164, item4 = 60165}) then
+    if kt_flag == 24 then
+      e.other:Message(MT.NPCQuestSay, "Tublik grunts unhappily at the four pieces. 'I had hoped more work wouldn't be needed to uncover the clues, but it looks like there's a bit more you're going to need to do for me. Take a look at these edges. Do you see how they look really sinewy? That's because they're [" .. eq.say_link("made of flesh") .. "], probably that of the trusik. No doubt the Muramites have been quite cruel to them now that they are mostly used for slavery.'")
+      e.other:SummonItem(60162)
+      e.other:SummonItem(60163)
+      e.other:SummonItem(60164)
+      e.other:SummonItem(60165)
+      e.other:SetAccountBucket("god.flags.kt", "25")
+    else
+      item_lib.return_items(e.self, e.other, e.trade)
+    end
   end
 
-  if item_lib.check_turn_in(e.trade, {item1 = 60166}) and kt_flag == 25 then 
-    e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'Nicely sewn, " .. e.other:GetCleanName() .. ". I would have tried doing it myself, but I have the most unsteady fingers when it comes to things like that. In any case, let me have a look at what this says.' Tublik looks over the clue for a time before continuing. 'Unbelievable. Simply astounding. These notes weren't made by the Muramites at all. In fact, they were created by trusik priests from their own flesh in some kind of [" .. eq.say_link("ritual") .. "].'")
-    e.other:SetAccountBucket("god.flags.kt", "26")
+  if item_lib.check_turn_in(e.trade, {item1 = 60166}) then
+    if kt_flag == 25 then 
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'Nicely sewn, " .. e.other:GetCleanName() .. ". I would have tried doing it myself, but I have the most unsteady fingers when it comes to things like that. In any case, let me have a look at what this says.' Tublik looks over the clue for a time before continuing. 'Unbelievable. Simply astounding. These notes weren't made by the Muramites at all. In fact, they were created by trusik priests from their own flesh in some kind of [" .. eq.say_link("ritual") .. "].'")
+      e.other:SetAccountBucket("god.flags.kt", "26")
+    else
+      item_lib.return_items(e.self, e.other, e.trade)
+    end
   end
 
-  if item_lib.check_turn_in(e.trade, {item1 = 60167, item2 = 60168, item3 = 60169}) and kt_flag == 26 then
-    e.other:Message(MT.NPCQuestSay, "Tublik stares at the three clues for a moment before speaking. 'I can't be sure, but I believe we are getting close to something big, " .. e.other:GetCleanName() .. ". I need more time to examine these clues, but I should have something for you when you return. You've done well and I know that we wouldn't have been able to get this far without your help. Good job!'")
-    e.other:SetAccountBucket("god.flags.kt", "27")
+  if item_lib.check_turn_in(e.trade, {item1 = 60167, item2 = 60168, item3 = 60169}) then
+    if kt_flag == 26 then
+      e.other:Message(MT.NPCQuestSay, "Tublik stares at the three clues for a moment before speaking. 'I can't be sure, but I believe we are getting close to something big, " .. e.other:GetCleanName() .. ". I need more time to examine these clues, but I should have something for you when you return. You've done well and I know that we wouldn't have been able to get this far without your help. Good job!'")
+      e.other:SetAccountBucket("god.flags.kt", "27")
+    else
+      item_lib.return_items(e.self, e.other, e.trade)
+    end
   end
 
-  if item_lib.check_turn_in(e.trade, {item = 60170}) and kt_flag == 27 then
-    e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'You've done it! You've recovered the first of the three artifacts! You must keep this with you, as you'll need it once you've recovered all three artifacts. The next temple is the[" .. eq.say_link("Sanctuary of the Glorified") .. "], are you ready".. e.other:GetCleanName() .. "?")
-    e.other:Message(MT.LightBlue, "Finished! - You've recovered the Artifact of Righteousness!")
-    e.other:SummonItem(60170)
-    e.other:SetAccountBucket("god.flags.kt", "28")
+  if item_lib.check_turn_in(e.trade, {item1 = 60170}) then
+    if kt_flag == 27 then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'You've done it! You've recovered the first of the three artifacts! You must keep this with you, as you'll need it once you've recovered all three artifacts. The next temple is the[" .. eq.say_link("Sanctuary of the Glorified") .. "], are you ready ".. e.other:GetCleanName() .. "?")
+      e.other:Message(MT.LightBlue, "Finished! - You've recovered the Artifact of Righteousness!")
+      e.other:SummonItem(60170)
+      e.other:SetAccountBucket("god.flags.kt", "28")
+    else
+      item_lib.return_items(e.self, e.other, e.trade)
+    end
   end
 
-  if item_lib.check_turn_in(e.trade, {item = 60171}) and kt_flag == 28 then
-    e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'You've done it! You've recovered the second of the three artifacts! You must keep this with you, because you'll need it once you've recovered all three artifacts. You only need one more from the [" .. eq.say_link("Sanctuary of the Transcendent") .. "]. Are you ready to progress forward with the final artifact?'")
-    e.other:Message(MT.LightBlue, "Finished! - You've recovered the Artifact of Glorification!")
-    e.other:SummonItem(60171)
-    e.other:SetAccountBucket("god.flags.kt", "29")
+  if item_lib.check_turn_in(e.trade, {item1 = 60171}) then 
+    if kt_flag == 28 then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'You've done it! You've recovered the second of the three artifacts! You must keep this with you, because you'll need it once you've recovered all three artifacts. You only need one more from the [" .. eq.say_link("Sanctuary of the Transcendent") .. "]. Are you ready to progress forward with the final artifact?'")
+      e.other:Message(MT.LightBlue, "Finished! - You've recovered the Artifact of Glorification!")
+      e.other:SummonItem(60171)
+      e.other:SetAccountBucket("god.flags.kt", "29")
+    else
+      item_lib.return_items(e.self, e.other, e.trade)
+    end
   end
 
-  if item_lib.check_turn_in(e.trade, {item = 60172}) and kt_flag == 29 then
-    e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'You've done it! You've recovered all three of the artifacts! You must keep this with you, because you'll need it now. Somewhere deep down I knew you would be able to get them all. I've been studying the markings from the artifacts and I've come to the conclusion that they must be combined to form a key to enter the [" .. eq.say_link("Altar of Destruction") .. "].'")
-    e.other:Message(MT.LightBlue, "Finished! - You've recovered the Artifact of Transcendence!")
-    e.other:SummonItem(60172)
-    e.other:SetAccountBucket("god.flags.kt", "30")
+  if item_lib.check_turn_in(e.trade, {item1 = 60172}) then
+    if kt_flag == 29 then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'You've done it! You've recovered all three of the artifacts! You must keep this with you, because you'll need it now. Somewhere deep down I knew you would be able to get them all. I've been studying the markings from the artifacts and I've come to the conclusion that they must be combined to form a key to enter the [" .. eq.say_link("Altar of Destruction") .. "].'")
+      e.other:Message(MT.LightBlue, "Finished! - You've recovered the Artifact of Transcendence!")
+      e.other:SummonItem(60172)
+      e.other:SetAccountBucket("god.flags.kt", "30")
+    else
+      item_lib.return_items(e.self, e.other, e.trade)
+    end
   end
 
-  if item_lib.check_turn_in(e.trade, {item = 60173}) and kt_flag == 31 then
-    e.other:Message(MT.NPCQuestSay, "Tublik scans the icon before returning it to you. 'You've done well, " .. e.other:GetCleanName() .. ". Up until now I hadn't noticed the final glyph that is created when the three pieces are combined. I must inspect this further, but return to me shortly and I should have an answer as to the glyph's meaning.'")
-    e.other:SummonItem(60172)
-    e.other:SetAccountBucket("god.flags.kt", "32")
+  if item_lib.check_turn_in(e.trade, {item1 = 60173}) then
+    if kt_flag == 31 then
+      e.other:Message(MT.NPCQuestSay, "Tublik scans the icon before returning it to you. 'You've done well, " .. e.other:GetCleanName() .. ". Up until now I hadn't noticed the final glyph that is created when the three pieces are combined. I must inspect this further, but return to me shortly and I should have an answer as to the glyph's meaning.'")
+      e.other:SummonItem(60173)
+      e.other:SetAccountBucket("god.flags.kt", "32")
+    else
+      item_lib.return_items(e.self, e.other, e.trade)
+    end
   end
 
-  if item_lib.check_turn_in(e.trade, {item = 60174}) and kt_flag == 32 then
-    e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'You've exceed all my expectations. This key is only the first of what looks to be three needed... needed for what I wonder? I imagine you'll find out more as you continue your adventures. Seek out Brevik in the Abysmal Sea should you discover anything else. He is one of the Wayfarers Brotherhood's resident geomancer adepts. He's not yet fully skilled, but he has much in the way of knowledge of the craft already and learning more each day. He will no doubt have more information for you. For now, I bid you good luck and farewell, " .. e.other:GetCleanName() .. "!'")
-    e.other:SummonItem(60176)
-    e.other:SetAccountBucket("god.flags.kt", "33")
+  if item_lib.check_turn_in(e.trade, {item1 = 60174}) then
+    if kt_flag == 32 then
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'You've exceed all my expectations. This key is only the first of what looks to be three needed... needed for what I wonder? I imagine you'll find out more as you continue your adventures. Seek out Brevik in the Abysmal Sea should you discover anything else. He is one of the Wayfarers Brotherhood's resident geomancer adepts. He's not yet fully skilled, but he has much in the way of knowledge of the craft already and learning more each day. He will no doubt have more information for you. For now, I bid you good luck and farewell, " .. e.other:GetCleanName() .. "!'")
+      e.other:SummonItem(60176)
+      e.other:SetAccountBucket("god.flags.kt", "33")
+    else
+      item_lib.return_items(e.self, e.other, e.trade)
+    end
   end
   item_lib.return_items(e.self, e.other, e.trade)
 end

--- a/kodtaz/Tublik_Narwethar.lua
+++ b/kodtaz/Tublik_Narwethar.lua
@@ -222,21 +222,38 @@ function event_trade(e)
   local kt_flag = tonumber(e.other:GetAccountBucket("god.flags.kt")) or 0
   local item_lib = require("items")
 
-  if item_lib.check_turn_in(e.trade, {item1 = 60146}) and kt_flag == 15 then
+  if item_lib.check_turn_in(e.trade, {item1 = 60146}) then
     e.other:SummonItem(60146)
-    give_tablet(e, kt_flag)
+    if kt_flag == 15 then
+      give_tablet(e, kt_flag)
+    else
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'I've already seen this glyph, you should use the stone tablet to translate it.'")
+    end
   end
-  if item_lib.check_turn_in(e.trade, {item1 = 60147}) and kt_flag == 15 then
+
+  if item_lib.check_turn_in(e.trade, {item1 = 60147}) then
     e.other:SummonItem(60147)
-    give_tablet(e, kt_flag)
+    if kt_flag == 15 then
+      give_tablet(e, kt_flag)
+    else
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'I've already seen this glyph, you should use the stone tablet to translate it.'")
+    end
   end
-  if item_lib.check_turn_in(e.trade, {item1 = 60148}) and kt_flag == 15 then
+  if item_lib.check_turn_in(e.trade, {item1 = 60148}) then
     e.other:SummonItem(60148)
-    give_tablet(e, kt_flag)
+    if kt_flag == 15 then
+      give_tablet(e, kt_flag)
+    else
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'I've already seen this glyph, you should use the stone tablet to translate it.'")
+    end
   end
-  if item_lib.check_turn_in(e.trade, {item1 = 60148}) and kt_flag == 15 then
-    e.other:SummonItem(60148)
-    give_tablet(e, kt_flag)
+  if item_lib.check_turn_in(e.trade, {item1 = 60149}) then
+    e.other:SummonItem(60149)
+    if kt_flag == 15 then
+      give_tablet(e, kt_flag)
+    else
+      e.other:Message(MT.NPCQuestSay, "Tublik Narwethar says 'I've already seen this glyph, you should use the stone tablet to translate it.'")
+    end
   end
 
   if item_lib.check_turn_in(e.trade, {item1 = 60156, item2 = 60157, item3 = 60158, item4 = 60159}) and kt_flag == 20 then
@@ -300,6 +317,7 @@ function event_trade(e)
     e.other:SummonItem(60176)
     e.other:SetAccountBucket("god.flags.kt", "33")
   end
+  item_lib.return_items(e.self, e.other, e.trade)
 end
 
 function give_tablet(e, kt_flag)

--- a/kodtaz/player.lua
+++ b/kodtaz/player.lua
@@ -10,3 +10,14 @@ function event_click_door(e)
 		end
 	end
 end
+
+function event_zone(e)
+  if e.zone_id == Zone.kodtaz or e.zone_id == Zone.yxtta then
+    local kt_flag = tonumber(e.self:GetAccountBucket("god.flags.kt")) or 0
+    if kt_flag >= 33 and e.self:HasItem(60176) and e.self:HasItem(60252) and not e.self:HasZoneFlag(Zone.qvic) then
+      e.self:SetZoneFlag(Zone.qvic)
+      e.self:SetAccountBucket("god.flags.kt", "34")
+      e.self:Message(MT.LightBlue, "The magical barrier protecting Qvic appears to have weakened, allowing access.")
+    end
+  end
+end

--- a/kodtaz/player.lua
+++ b/kodtaz/player.lua
@@ -11,13 +11,14 @@ function event_click_door(e)
 	end
 end
 
-function event_zone(e)
-  if e.zone_id == Zone.kodtaz or e.zone_id == Zone.yxtta then
-    local kt_flag = tonumber(e.self:GetAccountBucket("god.flags.kt")) or 0
-    if kt_flag >= 33 and e.self:HasItem(60176) and e.self:HasItem(60252) and not e.self:HasZoneFlag(Zone.qvic) then
-      e.self:SetZoneFlag(Zone.qvic)
-      e.self:SetAccountBucket("god.flags.kt", "34")
-      e.self:Message(MT.LightBlue, "The magical barrier protecting Qvic appears to have weakened, allowing access.")
-    end
+function event_enter_zone(e)
+  local kt_flag = tonumber(e.self:GetAccountBucket("god.flags.kt")) or 0
+  if kt_flag == 33 and e.self:HasItem(60176) and e.self:HasItem(60252) and not e.self:HasZoneFlag(Zone.qvic) then
+    e.self:SetZoneFlag(Zone.qvic)
+    e.self:SetAccountBucket("god.flags.kt", "34")
+    e.self:Message(MT.LightBlue, "The magical barrier protecting Qvic appears to have weakened, allowing access.")
+  elseif kt_flag == 34 and not e.self:HasZoneFlag(Zone.qvic) then
+    e.self:SetZoneFlag(Zone.qvic)
+    e.self:Message(MT.LightBlue, "The magical barrier protecting Qvic appears to have weakened, allowing access.")
   end
 end

--- a/natimbi/#Madronoa.lua
+++ b/natimbi/#Madronoa.lua
@@ -11,8 +11,11 @@ function event_say(e)
 			gm_bypass = true;
 		end
 		-- load the current qglobals
-		local qglobals = eq.get_qglobals(e.other);
-		if (gm_bypass or (e.other:HasZoneFlag(295) and tonumber(qglobals["god_qvic_access"]) >= 2)) then
+		local kt_flag == tonumber(e.other:GetAccountBucket("god.flags.kt")) or 0
+		if gm_bypass or e.other:HasZoneFlag(Zone.qvic) or kt_flag == 34 then
+		  	if not e.other:HasZoneFlag(Zone.qvic) then
+		        	e.other:SetZoneFlag(Zone.qvic)
+			end
 			-- send to safe spot in Qvic. Confirmed /loc on Live as of 2011/05/31
 			e.other:MovePC(295,-124,-651,-422,0); -- Zone: qvic
 		end

--- a/natimbi/#Madronoa.lua
+++ b/natimbi/#Madronoa.lua
@@ -11,7 +11,7 @@ function event_say(e)
 			gm_bypass = true;
 		end
 		-- load the current qglobals
-		local kt_flag == tonumber(e.other:GetAccountBucket("god.flags.kt")) or 0
+		local kt_flag = tonumber(e.other:GetAccountBucket("god.flags.kt")) or 0
 		if gm_bypass or e.other:HasZoneFlag(Zone.qvic) or kt_flag == 34 then
 		  	if not e.other:HasZoneFlag(Zone.qvic) then
 		        	e.other:SetZoneFlag(Zone.qvic)

--- a/natimbi/player.lua
+++ b/natimbi/player.lua
@@ -3,7 +3,7 @@ function event_click_door(e)
     kt_flag = tonumber(e.self:GetAccountBucket('god.flags.kt')) or 0
     vxed_flag = tonumber(e.self:GetAccountBucket('god.flags.vxed')) or 0
     tipt_flag = tonumber(e.self:GetAccountBucket('god.flags.tipt')) or 0
-    has_kt_access = (kt_flag >= 2)
+    has_kt_access = (kt_flag >= 1)
     has_vxed_access = (vxed_flag == 2)
     has_tipt_access = (tipt_flag == 2)
 

--- a/natimbi/player.lua
+++ b/natimbi/player.lua
@@ -1,0 +1,36 @@
+function event_click_door(e)
+  if e.door:GetDoorID() == 1 then
+    kt_flag = tonumber(e.self:GetAccountBucket('god.flags.kt')) or 0
+    vxed_flag = tonumber(e.self:GetAccountBucket('god.flags.vxed')) or 0
+    tipt_flag = tonumber(e.self:GetAccountBucket('god.flags.tipt')) or 0
+    has_kt_access = (kt_flag >= 2)
+    has_vxed_access = (vxed_flag == 2)
+    has_tipt_access = (tipt_flag == 2)
+
+    if has_kt_access and has_vxed_access and has_tipt_access then
+      if not e.self:HasZoneFlag(293) then
+	eq.debug('Updating zone flag')
+        e.self:SetZoneFlag(293)
+      end
+    end
+  end
+end
+
+function event_loot(e)
+  if(e.self:HasClass(Class.DRUID) and e.item:GetID() == 62889) then --Energized Noc Blood
+    local qglobals = eq.get_qglobals(e.self);
+    if(qglobals["druid_epic"] == "5") then
+      chest = tonumber(qglobals["druid_chest_natimbi"]) or 0
+      if chest == 0 then
+        e.other:SetGlobal("druid_chest_natimbi", "1", 5, "F");
+	local x = e.self:GetX()
+	local y = e.self:GetY()
+	local z = e.self:GetZ()
+        eq.spawn2(283157,0,0,x,y,z,0)
+      end
+      return 0
+    else
+      return 1
+    end
+  end
+end

--- a/natimbi/player.lua
+++ b/natimbi/player.lua
@@ -9,7 +9,6 @@ function event_click_door(e)
 
     if has_kt_access and has_vxed_access and has_tipt_access then
       if not e.self:HasZoneFlag(293) then
-	eq.debug('Updating zone flag')
         e.self:SetZoneFlag(293)
       end
     end

--- a/qvic/player.lua
+++ b/qvic/player.lua
@@ -11,9 +11,13 @@ function event_click_door(e)
 	local door_id = e.door:GetDoorID();
 	--Txevu
 	if (door_id == 2) then
-		if(e.self:HasItem(60254)) then
+		txevu_flag = tonumber(e.self:GetAccountBucket('god.flags.txevu')) or 0
+		if e.self:HasItem(60254) or txevu_flag == 1 then
 			if not e.self:HasZoneFlag(297) then
 				e.self:SetZoneFlag(297);
+			end
+			if txevu_flag == 0 then
+				e.self:SetAccountBucket('god.flags.txevu', '1')
 			end
 		end
 		--allow a GM to pull in a raid to test

--- a/sncrematory/#Gzifa_the_Pure_One.lua
+++ b/sncrematory/#Gzifa_the_Pure_One.lua
@@ -7,7 +7,7 @@ local function update_flag(client)
         client:Message(MT.Yellow, "You have gained a character flag!  Freedom for the souls that were trapped should earn the respect of High Priest Diru.")
     else
 	client:SetAccountBucket("god.flags.crematory", "1")
-	client:Message(MT.Yellow, "You have gained a temporary character flag!  Seek out the High Priest to find out more information.")
+	client:Message(MT.Yellow, "You have gained a temporary character flag!  Seek out the High Priest's scribe to find out more information.")
     end
 end
 

--- a/sncrematory/#Gzifa_the_Pure_One.lua
+++ b/sncrematory/#Gzifa_the_Pure_One.lua
@@ -1,15 +1,14 @@
 -- items: 55608, 55609, 55610, 55611
 local function update_flag(client)
-  local sewers_flag = tonumber(eq.get_data(client:CharacterID() .. "-god_sewers")) or 0
-  local sncrematory_key = string.format("%s-god_sncrematory", client:CharacterID())
-
-  if sewers_flag < 2 then
-    eq.set_data(sncrematory_key, "T")
-    client:Message(MT.Yellow, "You have gained a temporary character flag!  Seek the High Priest's Scribe to find out more information.")
-  else
-    eq.set_data(sncrematory_key, "1")
-    client:Message(MT.Yellow, "You have gained a character flag!  Freedom for the souls that were trapped should earn the respect of High Priest Diru.")
-  end
+    local sewers_bucket = tonumber(client:GetAccountBucket("god.flags.sewers")) or 0
+    local plant_bucket = tonumber(client:GetAccountBucket("god.flags.plant")) or 0
+    if sewers_bucket == 1 and plant_bucket == 3 then
+        client:SetAccountBucket("god.flags.crematory", "2")
+        client:Message(MT.Yellow, "You have gained a character flag!  Freedom for the souls that were trapped should earn the respect of High Priest Diru.")
+    else
+	client:SetAccountBucket("god.flags.crematory", "1")
+	client:Message(MT.Yellow, "You have gained a temporary character flag!  Seek out the High Priest to find out more information.")
+    end
 end
 
 function event_spawn(e)

--- a/sncrematory/#gzifa_trigger.lua
+++ b/sncrematory/#gzifa_trigger.lua
@@ -22,9 +22,11 @@ function event_enter(e)
   -- spawns but anyone can have the skulls. live seems to just poll the area.
   -- skulls cannot be spread between characters, one character must have them all
   if not event_started then
-    local sewers_flag = tonumber(eq.get_data(e.other:CharacterID() .. "-god_sewers")) or 0
+    local sewers_flag = tonumber(e.other:GetAccountBucket('god.flags.sewers')) or 0
+    local plant_flag = tonumber(e.other:GetAccountBucket('god.flags.plant')) or 0
+    eq.debug(string.format("sewers_flag: %s, plant_flag: %s", sewers_flag, plant_flag))
 
-    if sewers_flag == 2 then
+    if sewers_flag == 1 and plant_flag == 3 then
       chars_with_flag_inside[e.other:CharacterID()] = true
     end
 

--- a/snlair/Alej_Leraji.lua
+++ b/snlair/Alej_Leraji.lua
@@ -3,15 +3,16 @@ local turned_in_seal = false
 local tool_count = 0
 
 local function update_flag(client)
-  local sewers_flag = tonumber(eq.get_data(client:CharacterID() .. "-god_sewers")) or 0
-  local snlair_key = string.format("%s-god_snlair", client:CharacterID())
+  local sewers_flag = tonumber(client:GetAccountBucket("god.flags.sewers")) or 0
+  local plant_flag = tonumber(client:GetAccountBucket("god.flags.plant")) or 0
+  local crem_flag = tonumber(client:GetAccountBucket("god.flags.crematory")) or 0
 
-  if sewers_flag < 3 then
-    eq.set_data(snlair_key, "T")
-    client:Message(MT.Yellow, "You have gained a temporary character flag!  Seek the High Priest's Scribe to find out more information.")
-  else
-    eq.set_data(snlair_key, "1")
+  if sewers_flag == 1 and plant_flag == 3 and crem_flag == 3 then
+    client:SetAccountBucket("god.flags.lair", "2")
     client:Message(MT.Yellow, "You have gained a character flag!  All of High Priest Diru's tasks have been completed.  He will now tell you who to talk to for passage through the mountains.")
+  else
+    client:SetAccountBucket("god.flags.lair", "1")
+    client:Message(MT.Yellow, "You have gained a temporary character flag!  Seek out the High Priest to find out more information.")
   end
 end
 

--- a/snlair/Alej_Leraji.lua
+++ b/snlair/Alej_Leraji.lua
@@ -12,7 +12,7 @@ local function update_flag(client)
     client:Message(MT.Yellow, "You have gained a character flag!  All of High Priest Diru's tasks have been completed.  He will now tell you who to talk to for passage through the mountains.")
   else
     client:SetAccountBucket("god.flags.lair", "1")
-    client:Message(MT.Yellow, "You have gained a temporary character flag!  Seek out the High Priest to find out more information.")
+    client:Message(MT.Yellow, "You have gained a temporary character flag!  Seek out the High Priest's scribe to find out more information.")
   end
 end
 

--- a/snplant/encounters/stonemites.lua
+++ b/snplant/encounters/stonemites.lua
@@ -19,7 +19,7 @@ local function update_flag(client)
 
   if sewers_flag == 0 then -- never received preflag by hailing high priest
     client:SetAccountBucket("god.flags.plant", "1")
-    client:message(MT.Yellow, "You have gained a temporary character flag!  Andaru is happy that you have helped your friends slay the Ancient Kayserops.  Perhaps you should find the High Priest in Barindu for more information.")
+    client:message(MT.Yellow, "You have gained a temporary character flag!  Andaru is happy that you have helped your friends slay the Ancient Kayserops.  Perhaps you should talk to the High Priest in Barindu for more information.")
   else
     client:SetAccountBucket("god.flags.plant", "2")
     client:Message(MT.Yellow, "You have gained a character flag!  The destruction of the Ancient Kayserops should earn the trust of High Priest Diru.")

--- a/snplant/encounters/stonemites.lua
+++ b/snplant/encounters/stonemites.lua
@@ -15,14 +15,13 @@ local function spawn_stonemites()
 end
 
 local function update_flag(client)
-  local sewers_flag = tonumber(eq.get_data(client:CharacterID() .. "-god_sewers")) or 0
-  local snplant_key = string.format("%s-god_snplant", client:CharacterID())
+  local sewers_flag = tonumber(client:GetAccountBucket("god.flags.sewers")) or 0
 
   if sewers_flag == 0 then -- never received preflag by hailing high priest
-    eq.set_data(snplant_key, "T")
-    client:Message(MT.Yellow, "You have gained a temporary character flag!  Andaru is happy that you have helped your friends slay the Ancient Kayserops.  Perhaps you should find the High Priest in Barindu and ask him how else you can help the Taelosians.")
+    client:SetAccountBucket("god.flags.plant", "1")
+    client:message(MT.Yellow, "You have gained a temporary character flag!  Andaru is happy that you have helped your friends slay the Ancient Kayserops.  Perhaps you should find the High Priest in Barindu for more information.")
   else
-    eq.set_data(snplant_key, "1")
+    client:SetAccountBucket("god.flags.plant", "2")
     client:Message(MT.Yellow, "You have gained a character flag!  The destruction of the Ancient Kayserops should earn the trust of High Priest Diru.")
   end
 end
@@ -63,19 +62,19 @@ function ansharu_spawn(e)
 end
 
 function ansharu_say(e)
-  local sewers_flag = tonumber(eq.get_data(e.other:CharacterID() .. "-god_sewers")) or 0
-  local snplant_complete = (eq.get_data(string.format("%s-god_snplant", e.other:CharacterID())) == "1")
+  local sewers_flag = tonumber(e.other:GetAccountBucket("god.flags.sewers")) or 0
+  local plant_flag = tonumber(e.other:GetAccountBucket("god.flags.plant")) or 0
 
   if e.message:findi("hail") then
     if sewers_flag == 0 then
       e.other:Message(MT.NPCQuestSay, "Ansharu tells you, 'Please, keep your voice down.  I am here against the wishes of the invaders.  I must study the entomology of the stonemites that infest this area of the sewers.  So now, you must leave from my sight before you draw attention to me.'")
-    elseif sewers_flag == 1 and not snplant_complete then
+    elseif sewers_flag == 1 and plant_flag == 0 then
       e.other:Message(MT.NPCQuestSay, "Ansharu tells you, 'Diru sent you yes?  I am so happy you have come to help us.  I have determined that the source of the problem lies in the alpha leader of these stonemites.  It is a large and ancient stonemite that I have named the Kayserops.  I noticed that when together with it they are able to move about more effectively, as if it is able to communicate with them where to go.  Without this alpha leader, I think they would lose this ability and may have a harder time finding their way in to the city.  Find the aged stonemites. I have seen the Kayserops protecting these elders.  Defeating them may draw its attention.'")
       if event == state.None then
         spawn_stonemites()
         event = state.Spawned
       end
-    elseif sewers_flag == 1 then -- haven't hailed high priest after completing
+    elseif sewers_flag == 1 and (plant_flag == 1 or plant_flag == 2) then -- haven't hailed high priest after completing
       e.other:Message(MT.NPCQuestSay, "Ansharu tells you, 'I heard the squeal of the massive Kayserops even here.  Excellent work!  I hope that another leader does not rise to take its place any time soon.  You must go back and tell Diru of what has happened here!'")
     else
       e.other:Message(MT.NPCQuestSay, "Ansharu tells you, 'I heard from Diru that you have begun to help us in with our problems.  I cannot thank you enough for this.  Long have we been plagued with these invaders, and anything that you do to help gives us hope that one day we can live free.  Thank you again and safe journey to you.'")

--- a/snpool/#Utandi.lua
+++ b/snpool/#Utandi.lua
@@ -12,7 +12,7 @@ local function update_flag(client)
     client:Message(MT.Yellow, "You have gained a character flag!  The passage through the mountains is now clear in your mind.")
   else
     client:SetAccountBucket("god.flags.pool", "1")
-    client:Message(MT.Yellow, "You have gained a temporary character flag!  Seek the High Priest's Scribe to find out more information.")
+    client:Message(MT.Yellow, "You have gained a temporary character flag!  Seek out the High Priest's Scribe to find out more information.")
   end
 end
 

--- a/snpool/#Utandi.lua
+++ b/snpool/#Utandi.lua
@@ -2,15 +2,17 @@
 local event_started = false
 
 local function update_flag(client)
-  local sewers_flag = tonumber(eq.get_data(client:CharacterID() .. "-god_sewers")) or 0
-  local snpool_key = string.format("%s-god_snpool", client:CharacterID())
+  local sewers_flag = tonumber(client:GetAccountBucket("god.flags.sewers")) or 0
+  local plant_flag = tonumber(client:GetAccountBucket("god.flags.plant")) or 0
+  local crem_flag = tonumber(client:GetAccountBucket("god.flags.crematory")) or 0
+  local lair_flag = tonumber(client:GetAccountBucket("god.flags.lair")) or 0
 
-  if sewers_flag < 4 then
-    eq.set_data(snpool_key, "T")
-    client:Message(MT.Yellow, "You have gained a temporary character flag!  Seek the High Priest's Scribe to find out more information.")
-  else
-    eq.set_data(snpool_key, "1")
+  if sewers_flag == 1 and plant_flag == 3 and crem_flag == 3 and lair_flag == 3 then
+    client:SetAccountBucket("god.flags.pool", "2") 
     client:Message(MT.Yellow, "You have gained a character flag!  The passage through the mountains is now clear in your mind.")
+  else
+    client:SetAccountBucket("god.flags.pool", "1")
+    client:Message(MT.Yellow, "You have gained a temporary character flag!  Seek the High Priest's Scribe to find out more information.")
   end
 end
 
@@ -23,9 +25,12 @@ function event_spawn(e)
 end
 
 function event_say(e)
-  local sewers_flag = tonumber(eq.get_data(e.other:CharacterID() .. "-god_sewers")) or 0
-  local snpool_complete = (eq.get_data(e.other:CharacterID() .. "-god_snpool") == "1")
-  local on_progression = (sewers_flag == 4 and not snpool_complete)
+  local sewers_flag = tonumber(e.other:GetAccountBucket('god.flags.sewers')) or 0
+  local plant_flag = tonumber(e.other:GetAccountBucket('god.flags.plant')) or 0
+  local crem_flag = tonumber(e.other:GetAccountBucket('god.flags.crematory')) or 0
+  local lair_flag = tonumber(e.other:GetAccountBucket('god.flags.lair')) or 0
+  local pool_flag = tonumber(e.other:GetAccountBucket('god.flags.pool')) or 0
+  local on_progression = (sewers_flag == 1 and plant_flag == 3 and crem_flag == 3 and lair_flag == 3 and pool_flag == 0)
 
   if on_progression and (e.message:findi("hail") or e.message:find("hello")) then
     e.other:Message(MT.NPCQuestSay, "Utandi tells you, 'Wh, who are you?'  Utandi's voice quivers with fear.  'I have nothing of value if you are planning to rob me.  What's that?  You will not harm me?  You seek treasures elsewhere?  You think like I do.  I myself am in search of treasures.  There is only one [" .. eq.say_link("problem") .. "] though.'")

--- a/tipt/#Master_Stonespiritist_Okkanu.lua
+++ b/tipt/#Master_Stonespiritist_Okkanu.lua
@@ -16,7 +16,7 @@ function event_say(e)
         e.other:SetAccountBucket("god.flags.kt", "1")
         e.other:Message(MT.LightBlue, "You have gained a character flag!")
       else
-       e.other:Message(MT.Yellow, "You have gained a temporary character flag!  Seek the High Priest's Scribe to find out more information.")
+       e.other:Message(MT.Yellow, "You have gained a temporary character flag!  Seek out the High Priest's Scribe to find out more information.")
        e.other:SetAccountBucket("god.flags.tipt", "1")
       end
     end

--- a/tipt/#Master_Stonespiritist_Okkanu.lua
+++ b/tipt/#Master_Stonespiritist_Okkanu.lua
@@ -1,8 +1,8 @@
 function event_say(e)
   local tipt_flag = tonumber(e.other:GetAccountBucket("god.flags.tipt")) or 0
-  local kt_flag = tonumber(e.other:GetAccountBucket("god.flags.kt")) or 0
-  local has_kodtaz_access = (kt_flag == 2)
-  local has_tipt_access = (tipt_flag == 2)
+  local vxed_flag = tonumber(e.other:GetAccountBucket("god.flags.vxed")) or 0
+  local has_kodtaz_access = (tipt_flag == 2 and vxed_flag == 2)
+  local has_tipt_access = (vxed_flag == 2)
 
   if e.message:findi("hail") then
     -- this expedition gets locked so no need to track flagged count
@@ -12,10 +12,12 @@ function event_say(e)
       -- live gives the same message whether it's a temporary or permanent flag
       e.other:Message(MT.NPCQuestSay, "Okkanu tells you, 'I'm sorry, I can do nothing for you my friend.  Your bravery is notable, but I'm sure you can understand that we just can't trust anyone with our ancient magic.  It would be far too dangerous for my people.'")
       if has_tipt_access then
-        e.other:SetAccountBucket("god.flags.kt", "2")
+	e.other:SetAccountBucket("god.flags.tipt", "2")
+        e.other:SetAccountBucket("god.flags.kt", "1")
+        e.other:Message(MT.LightBlue, "You have gained a character flag!")
       else
        e.other:Message(MT.Yellow, "You have gained a temporary character flag!  Seek the High Priest's Scribe to find out more information.")
-       e.other:SetAccountBucket("god.flags.kt", "1")
+       e.other:SetAccountBucket("god.flags.tipt", "1")
       end
     end
   end

--- a/tipt/#Master_Stonespiritist_Okkanu.lua
+++ b/tipt/#Master_Stonespiritist_Okkanu.lua
@@ -1,9 +1,8 @@
 function event_say(e)
-  local qglobals = eq.get_qglobals(e.other)
-  local has_tipt_access = (qglobals.god_tipt_access and qglobals.god_tipt_access == "1")
-  local has_kodtaz_access = (qglobals.god_kodtaz_access and qglobals.god_kodtaz_access == "1")
-
-  local tipt_flag_key = string.format("%s-god_tipt", e.other:CharacterID())
+  local tipt_flag = tonumber(e.other:GetAccountBucket("god.flags.tipt")) or 0
+  local kt_flag = tonumber(e.other:GetAccountBucket("god.flags.kt")) or 0
+  local has_kodtaz_access = (kt_flag == 2)
+  local has_tipt_access = (tipt_flag == 2)
 
   if e.message:findi("hail") then
     -- this expedition gets locked so no need to track flagged count
@@ -12,13 +11,11 @@ function event_say(e)
     else
       -- live gives the same message whether it's a temporary or permanent flag
       e.other:Message(MT.NPCQuestSay, "Okkanu tells you, 'I'm sorry, I can do nothing for you my friend.  Your bravery is notable, but I'm sure you can understand that we just can't trust anyone with our ancient magic.  It would be far too dangerous for my people.'")
-      e.other:Message(MT.Yellow, "You have gained a temporary character flag!  Seek the High Priest's Scribe to find out more information.")
-
       if has_tipt_access then
-        eq.set_data(tipt_flag_key, "1")
-        eq.set_global("god_kodtaz_access", "1", 5, "F") -- make permanent
+        e.other:SetAccountBucket("god.flags.kt", "2")
       else
-        eq.set_data(tipt_flag_key, "T")
+       e.other:Message(MT.Yellow, "You have gained a temporary character flag!  Seek the High Priest's Scribe to find out more information.")
+       e.other:SetAccountBucket("god.flags.kt", "1")
       end
     end
   end

--- a/tipt/player.lua
+++ b/tipt/player.lua
@@ -17,9 +17,9 @@ function event_click_door(e)
   elseif door_id == 5 then -- obelisk zone out behind Master Stonespiritist Okkanu
     -- if a player hasn't hailed Master Spiritist to get either temp or
     -- permanent Tipt flag then the port out stone doesn't work for them
-    local kt_flag = tonumber(e.self:GetDataBuckets('god.flags.kt')) or 0
-    local has_perm_flag = (kt_flag == 2)
-    local has_temp_flag = (kt_flag == 1)
+    local tipt_flag = tonumber(e.self:GetAccountBucket('god.flags.tipt')) or 0
+    local has_perm_flag = (tipt_flag == 2)
+    local has_temp_flag = (tipt_flag == 1)
 
     if not has_temp_flag and not has_perm_flag then
       e.self:Message(MT.Yellow, "Master Stonespiritist Okkanu glares at you as you touch the strangely runed obelisk.")

--- a/tipt/player.lua
+++ b/tipt/player.lua
@@ -17,9 +17,9 @@ function event_click_door(e)
   elseif door_id == 5 then -- obelisk zone out behind Master Stonespiritist Okkanu
     -- if a player hasn't hailed Master Spiritist to get either temp or
     -- permanent Tipt flag then the port out stone doesn't work for them
-    local qglobals = eq.get_qglobals(e.self) -- god_kodtaz_access currently represents permanent flag
-    local has_perm_flag = (qglobals.god_kodtaz_access and qglobals.god_kodtaz_access == "1")
-    local has_temp_flag = (eq.get_data(string.format("%s-god_tipt", e.self:CharacterID())) == "T")
+    local kt_flag = tonumber(e.self:GetDataBuckets('god.flags.kt')) or 0
+    local has_perm_flag = (kt_flag == 2)
+    local has_temp_flag = (kt_flag == 1)
 
     if not has_temp_flag and not has_perm_flag then
       e.self:Message(MT.Yellow, "Master Stonespiritist Okkanu glares at you as you touch the strangely runed obelisk.")

--- a/txevu/Hamari_Nedu.lua
+++ b/txevu/Hamari_Nedu.lua
@@ -2,7 +2,7 @@ local tacvi = "Tacvi, Seat of the Slaver"
 local min_players = 1
 local max_players = 54
 if (eq.get_rule("Custom:MulticlassingEnabled") == "true" ) then
-	max_players = 1
+	min_players = 1
     max_players = 6
 end
 local tacvi_raid = {
@@ -14,8 +14,9 @@ local tacvi_raid = {
 }
 
 function event_say(e) 
+	tacvi_flag = tonumber(e.other:GetAccountBucket("god.flags.tacvi")) or 0
 	if e.message:findi("hail") then
-		if e.other:HasItem(64034) then
+		if e.other:HasItem(64034) or tacvi_flag == 1 then
 			e.self:Say("You hold a Signet of Command! I can use the power of the signet to [" .. eq.say_link("open the way") .. "] for you to the upper reaches of the temple once you are prepared to face the Tunat'Muram.");
 		else
 			--#if don't have signet of command		
@@ -32,13 +33,16 @@ function event_say(e)
 	elseif e.message:findi("open the way") then
 		local is_gm = e.other:GetGM();
 
-		if e.other:HasItem(64034) then
+		if e.other:HasItem(64034) or tacvi_flag == 1 then
 			if not is_gm and e.other:DoesAnyPartyMemberHaveLockout(tacvi, "Replay Timer", 54) then
 				e.other:Message(MT.NPCQuestSay, "Hamari Nedu says, 'I'm afraid I cannot allow you to begin, someone in your party has been on this expedition too recently and cannot yet go again.'")
 			else
 				e.other:Message(MT.NPCQuestSay, "Hamari Nedu says, 'Place your hands on one of the altars behind me and the way will be revealed. Be wary for you are about to encounter some of the most vicious trusik known. If for any reason you wish to return, place your hands on the golem within the temple.'");
 				local dz = e.other:CreateExpedition(tacvi_raid)
-				-- dz:AddReplayLockout(eq.seconds("22h"));
+				dz:AddReplayLockout(eq.seconds("14h"));
+				if tacvi_flag == 0 then
+					e.other:SetAccountBucket("god.flags.tacvi", "1")
+				end
 			end
 		end
 	end

--- a/vxed/#Stonespiritist_Ekikoa.lua
+++ b/vxed/#Stonespiritist_Ekikoa.lua
@@ -2,6 +2,7 @@ local flagged_count = 0
 
 local function update_flags(client)
   local vxed_flag = tonumber(client:GetAccountBucket("god.flags.vxed")) or 0
+  local pool_flag = tonumber(client:GetAccountBucket("god.flags.pool")) or 0
 
   -- was able to flag 7 characters on live (2 permanent, 5 temporary) and didn't
   -- have enough characters to test limits. this is an assumption that live still
@@ -10,15 +11,15 @@ local function update_flags(client)
 
   if flagged_count >= 8 then
     client:Message(MT.NPCQuestSay, "Ekikoa tells you, 'I'm afraid that I have already aided as many as I can, I do not have the strength to assist you further.'")
-  elseif vxed_flag == 2 then
+  elseif pool_flag == 3 then
     client:Message(MT.NPCQuestSay, "Ekikoa tells you, 'This stone behind me is a shard of an Attunement Obelisk.  With a unique and ancient magic, we can attune spirits to this farstone to allow travel.  When you touch it, the stone will be imprinted with your essence, because this is only a section of an obelisk, more must be done in order to have full use of these obelisks.  Now, when you touch this stone, you will be sent back to Udranda.  She will tell you what you must do next when you are ready.'")
     client:Message(MT.Yellow, "You feel at one with the Attunement Obelisk and feel the power of the earth moving through you.")
-    client:SetAccountBucket('god.flags.tipt', '2')
+    client:SetAccountBucket('god.flags.vxed', '2')
     flagged_count = flagged_count + 1
   else
     client:Message(MT.NPCQuestSay, "Ekikoa tells you, 'I'm afraid I can do nothing to aid you.  You have not proven yourself to be a faithful friend of my people.  You must complete High Priest Diru's tasks before I can be permitted to grant you access to our sacred magic.'")
     client:Message(MT.Yellow, "You have gained a temporary character flag!  Seek the High Priest's Scribe to find out more information.")
-    client:SetAccountBucket('god.flags.tipt', '1')
+    client:SetAccountBucket('god.flags.vxed', '1')
     flagged_count = flagged_count + 1
   end
 end
@@ -30,8 +31,8 @@ end
 function event_say(e)
   local tipt_flag = tonumber(e.other:GetAccountBucket("god.flags.tipt")) or 0
   local pool_flag = tonumber(e.other:GetAccountBucket("god.flags.pool")) or 0
-  local has_tipt_access = (tipt_flag == 1)
-  local from_sewers = (pool_flag >= 2)
+  local has_tipt_access = (vxed_flag == 3)
+  local from_sewers = (pool_flag == 3)
 
   if e.message:findi("hail") and not has_tipt_access then
     if from_sewers then 

--- a/vxed/#Stonespiritist_Ekikoa.lua
+++ b/vxed/#Stonespiritist_Ekikoa.lua
@@ -18,7 +18,7 @@ local function update_flags(client)
     flagged_count = flagged_count + 1
   else
     client:Message(MT.NPCQuestSay, "Ekikoa tells you, 'I'm afraid I can do nothing to aid you.  You have not proven yourself to be a faithful friend of my people.  You must complete High Priest Diru's tasks before I can be permitted to grant you access to our sacred magic.'")
-    client:Message(MT.Yellow, "You have gained a temporary character flag!  Seek the High Priest's Scribe to find out more information.")
+    client:Message(MT.Yellow, "You have gained a temporary character flag!  Seek out the High Priest's Scribe to find out more information.")
     client:SetAccountBucket('god.flags.vxed', '1')
     flagged_count = flagged_count + 1
   end

--- a/vxed/#Stonespiritist_Ekikoa.lua
+++ b/vxed/#Stonespiritist_Ekikoa.lua
@@ -3,6 +3,7 @@ local flagged_count = 0
 local function update_flags(client)
   local vxed_flag = tonumber(client:GetAccountBucket("god.flags.vxed")) or 0
   local pool_flag = tonumber(client:GetAccountBucket("god.flags.pool")) or 0
+  local ferubi_flag = tonumber(client:GetAccountBucket("god.flags.ferubi")) or 0
 
   -- was able to flag 7 characters on live (2 permanent, 5 temporary) and didn't
   -- have enough characters to test limits. this is an assumption that live still
@@ -11,7 +12,7 @@ local function update_flags(client)
 
   if flagged_count >= 8 then
     client:Message(MT.NPCQuestSay, "Ekikoa tells you, 'I'm afraid that I have already aided as many as I can, I do not have the strength to assist you further.'")
-  elseif pool_flag == 3 then
+  elseif pool_flag == 3 or ferubi_flag == 1 then
     client:Message(MT.NPCQuestSay, "Ekikoa tells you, 'This stone behind me is a shard of an Attunement Obelisk.  With a unique and ancient magic, we can attune spirits to this farstone to allow travel.  When you touch it, the stone will be imprinted with your essence, because this is only a section of an obelisk, more must be done in order to have full use of these obelisks.  Now, when you touch this stone, you will be sent back to Udranda.  She will tell you what you must do next when you are ready.'")
     client:Message(MT.Yellow, "You feel at one with the Attunement Obelisk and feel the power of the earth moving through you.")
     client:SetAccountBucket('god.flags.vxed', '2')

--- a/vxed/#Stonespiritist_Ekikoa.lua
+++ b/vxed/#Stonespiritist_Ekikoa.lua
@@ -1,27 +1,24 @@
 local flagged_count = 0
 
-local function update_flags(client, make_permanent)
-  -- temp vxed flag is converted to permanent at Scribe Gurru once sewers or rondo completed
-  local vxed_flag_key = string.format("%s-god_vxed", client:CharacterID())
-  local has_temp_vxed = eq.get_data(vxed_flag_key) == "T"
+local function update_flags(client)
+  local vxed_flag = tonumber(client:GetAccountBucket("god.flags.vxed")) or 0
 
   -- was able to flag 7 characters on live (2 permanent, 5 temporary) and didn't
   -- have enough characters to test limits. this is an assumption that live still
   -- has a limit to prevent excessive dzadd flagging
   eq.debug(string.format("flagged count [%s]", flagged_count))
 
-  if flagged_count >= 8 or has_temp_vxed then
+  if flagged_count >= 8 then
     client:Message(MT.NPCQuestSay, "Ekikoa tells you, 'I'm afraid that I have already aided as many as I can, I do not have the strength to assist you further.'")
-  elseif make_permanent then
+  elseif vxed_flag == 2 then
     client:Message(MT.NPCQuestSay, "Ekikoa tells you, 'This stone behind me is a shard of an Attunement Obelisk.  With a unique and ancient magic, we can attune spirits to this farstone to allow travel.  When you touch it, the stone will be imprinted with your essence, because this is only a section of an obelisk, more must be done in order to have full use of these obelisks.  Now, when you touch this stone, you will be sent back to Udranda.  She will tell you what you must do next when you are ready.'")
     client:Message(MT.Yellow, "You feel at one with the Attunement Obelisk and feel the power of the earth moving through you.")
-    eq.set_data(vxed_flag_key, "1")
-    eq.set_global("god_tipt_access", "1", 5, "F")
+    client:SetAccountBucket('god.flags.tipt', '2')
     flagged_count = flagged_count + 1
   else
     client:Message(MT.NPCQuestSay, "Ekikoa tells you, 'I'm afraid I can do nothing to aid you.  You have not proven yourself to be a faithful friend of my people.  You must complete High Priest Diru's tasks before I can be permitted to grant you access to our sacred magic.'")
     client:Message(MT.Yellow, "You have gained a temporary character flag!  Seek the High Priest's Scribe to find out more information.")
-    eq.set_data(vxed_flag_key, "T")
+    client:SetAccountBucket('god.flags.tipt', '1')
     flagged_count = flagged_count + 1
   end
 end
@@ -31,17 +28,18 @@ function event_spawn(e)
 end
 
 function event_say(e)
-  local qglobals = eq.get_qglobals(e.other)
-  local has_vxed_access = (qglobals.god_vxed_access and qglobals.god_vxed_access == "1") -- sewers or rondo complete
-  local has_tipt_access = (qglobals.god_tipt_access and qglobals.god_tipt_access == "1") -- permanent vxed flag complete
+  local tipt_flag = tonumber(e.other:GetAccountBucket("god.flags.tipt")) or 0
+  local pool_flag = tonumber(e.other:GetAccountBucket("god.flags.pool")) or 0
+  local has_tipt_access = (tipt_flag == 1)
+  local from_sewers = (pool_flag >= 2)
 
   if e.message:findi("hail") and not has_tipt_access then
-    if has_vxed_access then -- sewers progression completed dialogue (untested with smith rondo flag)
+    if from_sewers then 
       e.other:Message(MT.NPCQuestSay, "Ekikoa tells you, 'Ah, help has come.  I was told to expect friendly creatures from a distant land and here you are.  You are as alien as the others, but I know you have done good deeds for Udranda to send you here.  Now, I will tell you what you came for.  Obviously, the way to the temples is blocked. However, I [" .. eq.say_link("tend") .. "] to something very special here to overcome that problem.'")
     else
-      update_flags(e.other, has_vxed_access)
+      update_flags(e.other)
     end
   elseif e.message:findi("tend") and not has_tipt_access then
-    update_flags(e.other, has_vxed_access)
+    update_flags(e.other)
   end
 end

--- a/vxed/player.lua
+++ b/vxed/player.lua
@@ -31,11 +31,11 @@ function event_click_door(e)
 		-- if player hasn't hailed Stonespiritist Ekikoa to get either temp or
 		-- permanent Vxed flag then the port out stone doesn't work for them.
 		-- Unknown what happens if at flagged cap (if live even has one anymore)
-		local qglobals = eq.get_qglobals(e.self) -- god_kodtaz_access currently represents permanent flag
-		local has_perm_flag = (qglobals.god_tipt_access and qglobals.god_tipt_access == "1")
-		local has_temp_flag = (eq.get_data(string.format("%s-god_vxed", e.self:CharacterID())) == "T")
+		local tipt_flag = tonumber(e.self:GetAccountBucket("god.flags.vxed")) or 0
+		local has_perm_flag = (tipt_flag == 2)
+		local has_temp_flag = (tipt_flag == 1)
 
-		if not has_temp_flag and not has_perm_flag then
+		if not has_perm_flag and not has_temp_flag then
 		  e.self:Message(MT.Yellow, "You become dizzy as you inspect the stone slab.")
 		  return 1 -- prevent zone out
 		end

--- a/vxed/player.lua
+++ b/vxed/player.lua
@@ -31,9 +31,9 @@ function event_click_door(e)
 		-- if player hasn't hailed Stonespiritist Ekikoa to get either temp or
 		-- permanent Vxed flag then the port out stone doesn't work for them.
 		-- Unknown what happens if at flagged cap (if live even has one anymore)
-		local tipt_flag = tonumber(e.self:GetAccountBucket("god.flags.vxed")) or 0
-		local has_perm_flag = (tipt_flag == 2)
-		local has_temp_flag = (tipt_flag == 1)
+		local vxed_flag = tonumber(e.self:GetAccountBucket("god.flags.vxed")) or 0
+		local has_perm_flag = (vxed_flag == 2)
+		local has_temp_flag = (vxed_flag == 1)
 
 		if not has_perm_flag and not has_temp_flag then
 		  e.self:Message(MT.Yellow, "You become dizzy as you inspect the stone slab.")

--- a/yxtta/player.lua
+++ b/yxtta/player.lua
@@ -66,14 +66,15 @@ function enterzone(e)
 	eq.get_entity_list():FindDoor(16):SetLockPick(0);
 end
 
-function event_zone(e)
-  if e.zone_id == Zone.kodtaz or e.zone_id == Zone.yxtta then
-    local kt_flag = tonumber(e.self:GetAccountBucket("god.flags.kt")) or 0
-    if kt_flag >= 33 and e.self:HasItem(60176) and e.self:HasItem(60252) and not e.self:HasZoneFlag(Zone.qvic) then
-      e.self:SetZoneFlag(Zone.qvic)
-      e.self:SetAccountBucket("god.flags.kt", "34")
-      e.self:Message(MT.LightBlue, "The magical barrier protecting Qvic appears to have weakened, allowing access.")
-    end
+function event_enter_zone(e)
+  local kt_flag = tonumber(e.self:GetAccountBucket("god.flags.kt")) or 0
+  if kt_flag == 33 and e.self:HasItem(60176) and e.self:HasItem(60252) and not e.self:HasZoneFlag(Zone.qvic) then
+    e.self:SetZoneFlag(Zone.qvic)
+    e.self:SetAccountBucket("god.flags.kt", "34")
+    e.self:Message(MT.LightBlue, "The magical barrier protecting Qvic appears to have weakened, allowing access.")
+  elseif kt_flag == 34 and not e.self:HasZoneFlag(Zone.qvic) then
+    e.self:SetZoneFlag(Zone.qvic)
+    e.self:Message(MT.LightBlue, "The magical barrier protecting Qvic appears to have weakened, allowing access.")
   end
 end
 

--- a/yxtta/player.lua
+++ b/yxtta/player.lua
@@ -66,6 +66,17 @@ function enterzone(e)
 	eq.get_entity_list():FindDoor(16):SetLockPick(0);
 end
 
+function event_zone(e)
+  if e.zone_id == Zone.kodtaz or e.zone_id == Zone.yxtta then
+    local kt_flag = tonumber(e.self:GetAccountBucket("god.flags.kt")) or 0
+    if kt_flag >= 33 and e.self:HasItem(60176) and e.self:HasItem(60252) and not e.self:HasZoneFlag(Zone.qvic) then
+      e.self:SetZoneFlag(Zone.qvic)
+      e.self:SetAccountBucket("god.flags.kt", "34")
+      e.self:Message(MT.LightBlue, "The magical barrier protecting Qvic appears to have weakened, allowing access.")
+    end
+  end
+end
+
 function event_reset(e)
 	question			=	0;
 	expected_door		=	0;


### PR DESCRIPTION
* This changes all flags into account-wide
* Tested:
  * Golden Path for flagging for Vxed through the Sewers
  * Golden Path for flagging for Vxed through Ferubi
  * Golden Path for flagging for Tipt
  * Golden Path for flagging for Kod'taz
  * Golden Path for flagging for Qvic
  * Golden Path for flagging for Txevu
  * Golden Path for flagging for Tacvi
  * A new character can go from creation to Natimbi to Qvic (via Madranoa) to Txevu to immediately request Tacvi
  * A new character can go from creation to Natimbi to Kodtaz to Qvic to Txevu to immediately request Tacvi
  * Turning in items out of order returns them in Kod'taz
* Untested:
  * Temporary flags for Tipt, Vxed, and Sewers and hailing Riwirn / Scribe